### PR TITLE
Improvement/dashboard polish

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -229,7 +229,19 @@ private fun AppScreen(
                         isCombatActive = activeCombat != null,
                     )
 
-                    if (showDashboard && !isConversationVisible && !isCombatVisible) {
+                    AnimatedVisibility(
+                        visible = showDashboard && !isConversationVisible && !isCombatVisible,
+                        enter =
+                            slideInVertically(
+                                initialOffsetY = { fullHeight -> fullHeight },
+                                animationSpec = tween(durationMillis = 400, easing = EaseInOut),
+                            ) + fadeIn(animationSpec = tween(durationMillis = 400, easing = EaseInOut)),
+                        exit =
+                            slideOutVertically(
+                                targetOffsetY = { fullHeight -> fullHeight },
+                                animationSpec = tween(durationMillis = 400, easing = EaseInOut),
+                            ) + fadeOut(animationSpec = tween(durationMillis = 400, easing = EaseInOut)),
+                    ) {
                         DashboardScreen(
                             usersViewModel = usersViewModel,
                             metricsViewModel = metricsViewModel,

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_DraggableBar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_DraggableBar.kt
@@ -3,6 +3,8 @@ package com.bellako.kiwi.common.screens.components
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.Box
@@ -38,6 +40,7 @@ import com.bellako.kiwi.ui.getScreenHeight
 import kotlinx.coroutines.launch
 
 private const val SNAP_VELOCITY_THRESHOLD = 400f
+const val BAR_TRAVEL_ANIM_DURATION = 600
 
 /**
  * @param content placed inside the bar, called with param @currentStateIndex when modified
@@ -66,7 +69,10 @@ fun Kiwi_DraggableBar(
     var offsetY by remember { mutableFloatStateOf(statesBottom[currentStateIndex]) }
 
     LaunchedEffect(currentStateIndex) {
-        animatableOffset.animateTo(statesBottom[currentStateIndex])
+        animatableOffset.animateTo(
+            statesBottom[currentStateIndex],
+            animationSpec = tween(durationMillis = BAR_TRAVEL_ANIM_DURATION, easing = EaseInOut),
+        )
         offsetY = statesBottom[currentStateIndex]
     }
 
@@ -148,7 +154,14 @@ fun Kiwi_DraggableBar(
                                     val newIndex = statesBottom.indexOf(target)
                                     updateState(newIndex)
 
-                                    animatableOffset.animateTo(target)
+                                    animatableOffset.animateTo(
+                                        target,
+                                        animationSpec =
+                                            tween(
+                                                durationMillis = BAR_TRAVEL_ANIM_DURATION,
+                                                easing = EaseInOut,
+                                            ),
+                                    )
                                     offsetY = target
                                 }
                             },

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_DraggableBar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_DraggableBar.kt
@@ -180,9 +180,8 @@ fun Kiwi_DraggableBar(
                     .pointerInput(Unit) { /* prevent inputs behind this */ },
         )
 
-        val closestLargerIndex =
-            statesBottom.indexOf(statesBottom.filter { it >= animatableOffset.value }.minOrNull())
-        content(closestLargerIndex)
+        val closestIndex = statesBottom.indexOf(closestState(animatableOffset.value))
+        content(closestIndex)
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_DraggableBar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_DraggableBar.kt
@@ -167,7 +167,8 @@ fun Kiwi_DraggableBar(
                     .pointerInput(Unit) { /* prevent inputs behind this */ },
         )
 
-        val closestLargerIndex = statesBottom.indexOf(statesBottom.filter { it >= offsetY }.minOrNull())
+        val closestLargerIndex =
+            statesBottom.indexOf(statesBottom.filter { it >= animatableOffset.value }.minOrNull())
         content(closestLargerIndex)
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
@@ -10,12 +10,14 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -29,18 +31,23 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
+import com.bellako.kiwi.R
 import com.bellako.kiwi.analytics.FirebaseEventNames
 import com.bellako.kiwi.analytics.firebaseLogEvent
+import com.bellako.kiwi.audio.AudioManager
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_DraggableBar
 import com.bellako.kiwi.common.screens.components.Kiwi_H1
 import com.bellako.kiwi.common.screens.components.Kiwi_H3
+import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_Label2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
 import com.bellako.kiwi.common.screens.components.LoadingModal
@@ -63,7 +70,6 @@ import com.bellako.kiwi.features.metrics.model.IMetricsViewModel
 import com.bellako.kiwi.features.metrics.model.MetricsProvider
 import com.bellako.kiwi.features.metrics.tests.MetricsFakeViewModel
 import com.bellako.kiwi.features.nodes.tests.NodesFakeViewModel
-import com.bellako.kiwi.features.notifications.controller.NotificationManager
 import com.bellako.kiwi.features.personality.data.PersonalityState
 import com.bellako.kiwi.features.personality.model.IPersonalityViewModel
 import com.bellako.kiwi.features.personality.tests.PersonalityFakeViewModel
@@ -81,9 +87,9 @@ import java.time.LocalDate
 
 const val MONTH_SLIDE_ANIM_DURATION = 300
 const val DAY_TRANSITION_ANIM_DURATION = 550
-const val LAYOUT_TRANSITION_ANIM_DURATION = 300
+const val LAYOUT_TRANSITION_ANIM_DURATION = 1200
 
-const val STATE_HEIGHT_0 = 140
+const val STATE_HEIGHT_0 = 150
 const val STATE_HEIGHT_1 = 270
 const val STATE_HEIGHT_2 = 680
 val STATES = listOf(STATE_HEIGHT_0, STATE_HEIGHT_1, STATE_HEIGHT_2)
@@ -150,7 +156,11 @@ fun DashboardScreen(
                         .testTag(CommonTestTags.DASHBOARD_MODAL),
                 horizontalAlignment = Alignment.CenterHorizontally,
             ) {
-                Header()
+                Header(
+                    stateIndex = draggableStateIndex.intValue,
+                    statesCount = STATES.size,
+                    onStateChange = { newIndex -> draggableStateIndex.intValue = newIndex },
+                )
 
                 AnimatedContent(
                     targetState = currentStateIndex,
@@ -229,17 +239,72 @@ fun ComposableEngagementMeasuring(layout: String) {
 }
 
 @Composable
-private fun Header() {
+private fun Header(
+    stateIndex: Int,
+    statesCount: Int,
+    onStateChange: (Int) -> Unit,
+) {
+    val canGoDown = stateIndex > 0
+    val canGoUp = stateIndex < statesCount - 1
+
     Kiwi_Spacer()
     Row(
+        modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Kiwi_H3(
-            KiwiTextArguments(
-                ":: Daily Progress ::",
-                TextAlign.Center,
-                LocalKiwiColors.current.color6,
-            ),
+        LayoutChevron(
+            rotationDegrees = 0f,
+            enabled = canGoDown,
+            onClick = { onStateChange(stateIndex - 1) },
+        )
+
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center,
+        ) {
+            Kiwi_H3(
+                KiwiTextArguments(
+                    ":: Daily Progress ::",
+                    TextAlign.Center,
+                    LocalKiwiColors.current.color6,
+                ),
+            )
+        }
+
+        LayoutChevron(
+            rotationDegrees = 180f,
+            enabled = canGoUp,
+            onClick = { onStateChange(stateIndex + 1) },
+        )
+    }
+}
+
+@Composable
+@Suppress("MagicNumber")
+private fun LayoutChevron(
+    rotationDegrees: Float,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val context = LocalContext.current
+    Box(
+        modifier =
+            Modifier
+                .size(getResponsiveSizeHeight(36.dp))
+                .clickable(enabled = enabled) {
+                    AudioManager.playSFX(context, R.raw.snd_ui_tap)
+                    onClick()
+                },
+        contentAlignment = Alignment.Center,
+    ) {
+        Kiwi_Image(
+            R.drawable.ic_dialogue_arrow,
+            "Layout chevron",
+            modifier =
+                Modifier
+                    .size(getResponsiveSizeHeight(14.dp))
+                    .rotate(rotationDegrees)
+                    .alpha(if (enabled) 1f else KIWI_DISABLED_ALPHA),
         )
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionLayout
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -162,40 +164,47 @@ fun DashboardScreen(
                     onStateChange = { newIndex -> draggableStateIndex.intValue = newIndex },
                 )
 
-                AnimatedContent(
-                    targetState = currentStateIndex,
-                    transitionSpec = {
-                        fadeIn(animationSpec = tween(LAYOUT_TRANSITION_ANIM_DURATION)) togetherWith
-                            fadeOut(animationSpec = tween(LAYOUT_TRANSITION_ANIM_DURATION))
-                    },
-                    modifier = Modifier.fillMaxWidth(),
-                    contentAlignment = Alignment.TopCenter,
-                    label = "dashboardLayoutTransition",
-                ) { stateIndex ->
-                    if (stateIndex == 0) {
-                        DashboardScreen0_Hidden()
-                    } else if (stateIndex <= 1) {
-                        DashboardScreen1_Collapsed(
-                            goalsViewModel = goalsViewModel,
-                            metricsState = metricsState!!,
-                            isLoading = isLoading,
-                            onCalendarViewClicked = {
-                                shouldShowCalendarView.value = true
-                                draggableStateIndex.intValue = 2
-                            },
-                        )
-                    } else if (stateIndex <= 2) {
-                        DashboardScreen2_Expanded(
-                            context = context,
-                            coroutineScope = coroutineScope,
-                            usersViewModel = usersViewModel,
-                            metricsViewModel = metricsViewModel,
-                            metricsState = metricsState!!,
-                            personalityViewModel = personalityViewModel,
-                            goalsViewModel = goalsViewModel,
-                            shouldShowCalendarView = shouldShowCalendarView,
-                            isLoading = isLoading,
-                        )
+                @OptIn(ExperimentalSharedTransitionApi::class)
+                SharedTransitionLayout(modifier = Modifier.fillMaxWidth()) {
+                    AnimatedContent(
+                        targetState = currentStateIndex,
+                        transitionSpec = {
+                            fadeIn(animationSpec = tween(LAYOUT_TRANSITION_ANIM_DURATION)) togetherWith
+                                fadeOut(animationSpec = tween(LAYOUT_TRANSITION_ANIM_DURATION))
+                        },
+                        modifier = Modifier.fillMaxWidth(),
+                        contentAlignment = Alignment.TopCenter,
+                        label = "dashboardLayoutTransition",
+                    ) { stateIndex ->
+                        if (stateIndex == 0) {
+                            DashboardScreen0_Hidden()
+                        } else if (stateIndex <= 1) {
+                            DashboardScreen1_Collapsed(
+                                goalsViewModel = goalsViewModel,
+                                metricsState = metricsState!!,
+                                isLoading = isLoading,
+                                onCalendarViewClicked = {
+                                    shouldShowCalendarView.value = true
+                                    draggableStateIndex.intValue = 2
+                                },
+                                sharedTransitionScope = this@SharedTransitionLayout,
+                                animatedVisibilityScope = this@AnimatedContent,
+                            )
+                        } else if (stateIndex <= 2) {
+                            DashboardScreen2_Expanded(
+                                context = context,
+                                coroutineScope = coroutineScope,
+                                usersViewModel = usersViewModel,
+                                metricsViewModel = metricsViewModel,
+                                metricsState = metricsState!!,
+                                personalityViewModel = personalityViewModel,
+                                goalsViewModel = goalsViewModel,
+                                shouldShowCalendarView = shouldShowCalendarView,
+                                isLoading = isLoading,
+                                sharedTransitionScope = this@SharedTransitionLayout,
+                                animatedVisibilityScope = this@AnimatedContent,
+                            )
+                        }
                     }
                 }
             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
@@ -75,6 +75,7 @@ import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import java.time.LocalDate
 
 const val MONTH_SLIDE_ANIM_DURATION = 300
+const val DAY_TRANSITION_ANIM_DURATION = 550
 
 const val STATE_HEIGHT_0 = 140
 const val STATE_HEIGHT_1 = 270

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
@@ -268,6 +268,7 @@ fun SelectedMetricsTime(
     validMetrics: Boolean,
     expanded: Boolean,
     tag: String,
+    label: String = "",
 ) {
     val kiwiColors = LocalKiwiColors.current
 
@@ -275,7 +276,7 @@ fun SelectedMetricsTime(
         if (validMetrics) {
             DateUtils.parseTimeSeconds(currentSeconds)
         } else {
-            "No data"
+            DateUtils.parseTimeSeconds(0)
         }
 
     val maxString =
@@ -309,27 +310,39 @@ fun SelectedMetricsTime(
             ),
         )
     } else {
-        Row(
+        Column(
             modifier = Modifier.fillMaxWidth(),
         ) {
-            Kiwi_Label2(
-                KiwiTextArguments(
-                    currentString,
-                    TextAlign.Left,
-                    color = kiwiColors.color9,
-                    modifier =
-                        Modifier
-                            .testTag(tag),
-                ),
-            )
+            if (label.isNotEmpty()) {
+                Kiwi_Label2(
+                    KiwiTextArguments(
+                        label,
+                        TextAlign.Left,
+                        color = kiwiColors.color7D,
+                    ),
+                )
+            }
 
-            Kiwi_Label2(
-                KiwiTextArguments(
-                    maxString,
-                    TextAlign.Left,
-                    color = kiwiColors.color7D,
-                ),
-            )
+            Row {
+                Kiwi_Label2(
+                    KiwiTextArguments(
+                        currentString,
+                        TextAlign.Left,
+                        color = kiwiColors.color9,
+                        modifier =
+                            Modifier
+                                .testTag(tag),
+                    ),
+                )
+
+                Kiwi_Label2(
+                    KiwiTextArguments(
+                        maxString,
+                        TextAlign.Left,
+                        color = kiwiColors.color7D,
+                    ),
+                )
+            }
         }
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen.kt
@@ -4,6 +4,11 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -76,6 +81,7 @@ import java.time.LocalDate
 
 const val MONTH_SLIDE_ANIM_DURATION = 300
 const val DAY_TRANSITION_ANIM_DURATION = 550
+const val LAYOUT_TRANSITION_ANIM_DURATION = 300
 
 const val STATE_HEIGHT_0 = 140
 const val STATE_HEIGHT_1 = 270
@@ -146,31 +152,41 @@ fun DashboardScreen(
             ) {
                 Header()
 
-                if (currentStateIndex == 0) {
-                    // TODO pedir de nuevo el dia actual
-                    DashboardScreen0_Hidden()
-                } else if (currentStateIndex <= 1) {
-                    DashboardScreen1_Collapsed(
-                        goalsViewModel = goalsViewModel,
-                        metricsState = metricsState!!,
-                        isLoading = isLoading,
-                        onCalendarViewClicked = {
-                            shouldShowCalendarView.value = true
-                            draggableStateIndex.intValue = 2
-                        },
-                    )
-                } else if (currentStateIndex <= 2) {
-                    DashboardScreen2_Expanded(
-                        context = context,
-                        coroutineScope = coroutineScope,
-                        usersViewModel = usersViewModel,
-                        metricsViewModel = metricsViewModel,
-                        metricsState = metricsState!!,
-                        personalityViewModel = personalityViewModel,
-                        goalsViewModel = goalsViewModel,
-                        shouldShowCalendarView = shouldShowCalendarView,
-                        isLoading = isLoading,
-                    )
+                AnimatedContent(
+                    targetState = currentStateIndex,
+                    transitionSpec = {
+                        fadeIn(animationSpec = tween(LAYOUT_TRANSITION_ANIM_DURATION)) togetherWith
+                            fadeOut(animationSpec = tween(LAYOUT_TRANSITION_ANIM_DURATION))
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    contentAlignment = Alignment.TopCenter,
+                    label = "dashboardLayoutTransition",
+                ) { stateIndex ->
+                    if (stateIndex == 0) {
+                        DashboardScreen0_Hidden()
+                    } else if (stateIndex <= 1) {
+                        DashboardScreen1_Collapsed(
+                            goalsViewModel = goalsViewModel,
+                            metricsState = metricsState!!,
+                            isLoading = isLoading,
+                            onCalendarViewClicked = {
+                                shouldShowCalendarView.value = true
+                                draggableStateIndex.intValue = 2
+                            },
+                        )
+                    } else if (stateIndex <= 2) {
+                        DashboardScreen2_Expanded(
+                            context = context,
+                            coroutineScope = coroutineScope,
+                            usersViewModel = usersViewModel,
+                            metricsViewModel = metricsViewModel,
+                            metricsState = metricsState!!,
+                            personalityViewModel = personalityViewModel,
+                            goalsViewModel = goalsViewModel,
+                            shouldShowCalendarView = shouldShowCalendarView,
+                            isLoading = isLoading,
+                        )
+                    }
                 }
             }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen1_Collapsed.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen1_Collapsed.kt
@@ -127,6 +127,7 @@ private fun CollapsedSummaryCard(
                         metricsState.currentGoodTimeSeconds > 0 || metricsState.currentBadTimeSeconds > 0,
                         false,
                         DashboardModalTestTags.GOOD_TIME,
+                        label = "Good Apps",
                     )
 
                     Kiwi_Spacer(Spacing.xSmall)
@@ -137,6 +138,7 @@ private fun CollapsedSummaryCard(
                         metricsState.currentGoodTimeSeconds > 0 || metricsState.currentBadTimeSeconds > 0,
                         false,
                         DashboardModalTestTags.BAD_TIME,
+                        label = "Evil Apps",
                     )
                 }
             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen1_Collapsed.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen1_Collapsed.kt
@@ -2,6 +2,9 @@ package com.bellako.kiwi.features.dashboard.screens
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -32,6 +35,7 @@ import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun DashboardScreen1_Collapsed(
@@ -39,6 +43,8 @@ fun DashboardScreen1_Collapsed(
     metricsState: MetricsState,
     isLoading: Boolean,
     onCalendarViewClicked: () -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     ComposableEngagementMeasuring("collapsed")
 
@@ -51,10 +57,13 @@ fun DashboardScreen1_Collapsed(
             metricsState = metricsState,
             isLoading = isLoading,
             onCalendarViewClicked = onCalendarViewClicked,
+            sharedTransitionScope = sharedTransitionScope,
+            animatedVisibilityScope = animatedVisibilityScope,
         )
     }
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 private fun CollapsedSummaryCard(
@@ -62,6 +71,8 @@ private fun CollapsedSummaryCard(
     metricsState: MetricsState,
     isLoading: Boolean,
     onCalendarViewClicked: () -> Unit,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     val kiwiColors = LocalKiwiColors.current
 
@@ -107,12 +118,19 @@ private fun CollapsedSummaryCard(
                 Modifier
                     .padding(start = getResponsiveSizeHeight(Spacing.medium)),
             ) {
-                @Suppress("MagicNumber")
-                CurrentDayIndicator(
-                    getResponsiveSizeHeight(100.dp),
-                    animatedDailyGoalProgress,
-                    animatedAppUsageProgress,
-                )
+                with(sharedTransitionScope) {
+                    @Suppress("MagicNumber")
+                    CurrentDayIndicator(
+                        size = getResponsiveSizeHeight(100.dp),
+                        dailyGoalsProgress = animatedDailyGoalProgress,
+                        appUsageProgress = animatedAppUsageProgress,
+                        modifier =
+                            Modifier.sharedElement(
+                                rememberSharedContentState(key = "currentDayHeart"),
+                                animatedVisibilityScope = animatedVisibilityScope,
+                            ),
+                    )
+                }
             }
             Box(
                 Modifier

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen2_Expanded.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen2_Expanded.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -196,7 +197,7 @@ private fun ExpandedMetricsProgress(state: MetricsState) {
     ) {
         Box(modifier = Modifier.weight(1f)) {
             Column {
-                ExpandedMetricProgressTitle("Good Apps Time")
+                ExpandedMetricProgressTitle("Good Apps")
                 SelectedMetricsTime(
                     state.maxGoodTimeSeconds,
                     state.currentGoodTimeSeconds,
@@ -208,7 +209,7 @@ private fun ExpandedMetricsProgress(state: MetricsState) {
         }
         Box(modifier = Modifier.weight(1f)) {
             Column {
-                ExpandedMetricProgressTitle("Evil Apps Time")
+                ExpandedMetricProgressTitle("Evil Apps")
                 SelectedMetricsTime(
                     state.maxBadTimeSeconds,
                     state.currentBadTimeSeconds,
@@ -251,11 +252,34 @@ private fun ExpandedSummaryCard(
             ),
         )
 
-        goals.forEach { goal ->
-            key(goal.id) {
-                GoalComponent(goal, goalsViewModel)
+        if (goals.isEmpty()) {
+            Kiwi_Spacer(Spacing.small)
+
+            @Suppress("MagicNumber")
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(11555f / (2113f * 2f))
+                        .clip(RoundedCornerShape(getResponsiveSizeHeight(20.dp)))
+                        .background(LocalKiwiColors.current.color2B),
+                contentAlignment = Alignment.Center,
+            ) {
+                Kiwi_P2(
+                    KiwiTextArguments(
+                        "No Daily Challenges",
+                        TextAlign.Center,
+                        LocalKiwiColors.current.color7D,
+                    ),
+                )
+            }
+        } else {
+            goals.forEach { goal ->
+                key(goal.id) {
+                    GoalComponent(goal, goalsViewModel)
 //                ExpandedGoalComponent(goal)
-                Kiwi_Spacer(Spacing.xSmall)
+                    Kiwi_Spacer(Spacing.xSmall)
+                }
             }
         }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen2_Expanded.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen2_Expanded.kt
@@ -3,8 +3,17 @@ package com.bellako.kiwi.features.dashboard.screens
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.Crossfade
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -22,6 +31,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -29,6 +39,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -53,6 +69,24 @@ import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import kotlinx.coroutines.CoroutineScope
 
 val LocalGoalsViewModel = compositionLocalOf<IGoalsViewModel?> { null }
+
+@Suppress("MagicNumber")
+private fun Modifier.featherHorizontalEdges(): Modifier =
+    this
+        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+        .drawWithContent {
+            drawContent()
+            drawRect(
+                brush =
+                    Brush.horizontalGradient(
+                        0f to Color.Transparent,
+                        0.12f to Color.Black,
+                        0.88f to Color.Black,
+                        1f to Color.Transparent,
+                    ),
+                blendMode = BlendMode.DstIn,
+            )
+        }
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -96,6 +130,29 @@ fun DashboardScreen2_Expanded(
         label = "appUsageProgress",
     )
 
+    val dayTransitionDirection = remember { mutableIntStateOf(0) }
+
+    val dayTransitionSpec: AnimatedContentTransitionScope<String>.() -> ContentTransform = {
+        val direction = dayTransitionDirection.intValue
+        if (direction == 0) {
+            fadeIn(animationSpec = tween(DAY_TRANSITION_ANIM_DURATION)) togetherWith
+                fadeOut(animationSpec = tween(DAY_TRANSITION_ANIM_DURATION))
+        } else {
+            (
+                slideInHorizontally(
+                    animationSpec = tween(DAY_TRANSITION_ANIM_DURATION),
+                    initialOffsetX = { fullWidth -> fullWidth * direction },
+                ) + fadeIn(animationSpec = tween(DAY_TRANSITION_ANIM_DURATION))
+            ) togetherWith
+                (
+                    slideOutHorizontally(
+                        animationSpec = tween(DAY_TRANSITION_ANIM_DURATION),
+                        targetOffsetX = { fullWidth -> -fullWidth * direction },
+                    ) + fadeOut(animationSpec = tween(DAY_TRANSITION_ANIM_DURATION))
+                )
+        }
+    }
+
     ComposableEngagementMeasuring("expanded")
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -103,44 +160,85 @@ fun DashboardScreen2_Expanded(
     ) {
         Kiwi_Spacer(Spacing.xSmall)
 
-        SelectedDayText(metricsState)
+        AnimatedContent(
+            targetState = metricsState.date,
+            transitionSpec = dayTransitionSpec,
+            label = "selectedDayText",
+        ) { _ ->
+            SelectedDayText(metricsState)
+        }
 
-        if (shouldShowCalendarView.value) {
-            CalendarMonthView(
-                context = context,
-                isLoading = isLoading,
-                coroutineScope = coroutineScope,
-                usersViewModel = usersViewModel,
-                metricsViewModel = metricsViewModel,
-                metricsState = metricsState,
-                shouldShowCalendarView = shouldShowCalendarView,
-                personalityViewModel = personalityViewModel,
-                goalsViewModel = goalsViewModel,
-            )
-        } else {
-            Kiwi_Spacer(Spacing.small)
+        Crossfade(
+            targetState = shouldShowCalendarView.value,
+            animationSpec = tween(DAY_TRANSITION_ANIM_DURATION),
+            label = "calendarWeekToggle",
+        ) { showCalendar ->
+            if (showCalendar) {
+                CalendarMonthView(
+                    context = context,
+                    isLoading = isLoading,
+                    coroutineScope = coroutineScope,
+                    usersViewModel = usersViewModel,
+                    metricsViewModel = metricsViewModel,
+                    metricsState = metricsState,
+                    shouldShowCalendarView = shouldShowCalendarView,
+                    personalityViewModel = personalityViewModel,
+                    goalsViewModel = goalsViewModel,
+                    dayTransitionDirection = dayTransitionDirection,
+                )
+            } else {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Kiwi_Spacer(Spacing.small)
 
-            @Suppress("MagicNumber")
-            CurrentDayIndicator(
-                getResponsiveSizeHeight(180.dp),
-                animatedDailyGoalProgress,
-                animatedAppUsageProgress,
-            )
+                    AnimatedContent(
+                        targetState = metricsState.date,
+                        transitionSpec = dayTransitionSpec,
+                        label = "currentDayIndicator",
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .featherHorizontalEdges(),
+                        contentAlignment = Alignment.Center,
+                    ) { _ ->
+                        @Suppress("MagicNumber")
+                        CurrentDayIndicator(
+                            getResponsiveSizeHeight(180.dp),
+                            animatedDailyGoalProgress,
+                            animatedAppUsageProgress,
+                        )
+                    }
 
-            CalendarWeekView(
-                context = context,
-                coroutineScope = coroutineScope,
-                usersViewModel = usersViewModel,
-                metricsViewModel = metricsViewModel,
-                metricsState = metricsState,
-                personalityViewModel = personalityViewModel,
-                isLoading = isLoading,
-                goalsViewModel = goalsViewModel,
-            ) {
-                shouldShowCalendarView.value = true
+                    CalendarWeekView(
+                        context = context,
+                        coroutineScope = coroutineScope,
+                        usersViewModel = usersViewModel,
+                        metricsViewModel = metricsViewModel,
+                        metricsState = metricsState,
+                        personalityViewModel = personalityViewModel,
+                        isLoading = isLoading,
+                        goalsViewModel = goalsViewModel,
+                        dayTransitionDirection = dayTransitionDirection,
+                    ) {
+                        shouldShowCalendarView.value = true
+                    }
+
+                    AnimatedContent(
+                        targetState = metricsState.date,
+                        transitionSpec = dayTransitionSpec,
+                        label = "expandedProgressBox",
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .featherHorizontalEdges(),
+                        contentAlignment = Alignment.TopCenter,
+                    ) { _ ->
+                        ExpandedProgressBox(metricsState, goalsViewModel)
+                    }
+                }
             }
-
-            ExpandedProgressBox(metricsState, goalsViewModel)
         }
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen2_Expanded.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen2_Expanded.kt
@@ -5,8 +5,11 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -88,6 +91,7 @@ private fun Modifier.featherHorizontalEdges(): Modifier =
             )
         }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun DashboardScreen2_Expanded(
@@ -100,6 +104,8 @@ fun DashboardScreen2_Expanded(
     goalsViewModel: IGoalsViewModel,
     shouldShowCalendarView: MutableState<Boolean>,
     isLoading: Boolean,
+    sharedTransitionScope: SharedTransitionScope,
+    animatedVisibilityScope: AnimatedVisibilityScope,
 ) {
     var dailyGoalProgress by remember { mutableFloatStateOf(0f) }
     LaunchedEffect(metricsState) {
@@ -203,12 +209,19 @@ fun DashboardScreen2_Expanded(
                                 .featherHorizontalEdges(),
                         contentAlignment = Alignment.Center,
                     ) { _ ->
-                        @Suppress("MagicNumber")
-                        CurrentDayIndicator(
-                            getResponsiveSizeHeight(180.dp),
-                            animatedDailyGoalProgress,
-                            animatedAppUsageProgress,
-                        )
+                        with(sharedTransitionScope) {
+                            @Suppress("MagicNumber")
+                            CurrentDayIndicator(
+                                size = getResponsiveSizeHeight(180.dp),
+                                dailyGoalsProgress = animatedDailyGoalProgress,
+                                appUsageProgress = animatedAppUsageProgress,
+                                modifier =
+                                    Modifier.sharedElement(
+                                        rememberSharedContentState(key = "currentDayHeart"),
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                    ),
+                            )
+                        }
                     }
 
                     CalendarWeekView(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableIntState
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -216,6 +217,7 @@ fun CalendarWeekView(
     personalityViewModel: IPersonalityViewModel,
     isLoading: Boolean,
     goalsViewModel: IGoalsViewModel,
+    dayTransitionDirection: MutableIntState,
     onCalendarViewClicked: () -> Unit,
 ) {
     val date = stringToDate(metricsState.date)
@@ -264,13 +266,21 @@ fun CalendarWeekView(
                         onClicked = {
                             AudioManager.playSFX(context, R.raw.snd_ui_tap)
                             selectedDayIndex = index
+                            val newDay = startOfWeek.plusDays(index.toLong())
+                            val currentDay = stringToDate(metricsState.date)
+                            dayTransitionDirection.intValue =
+                                when {
+                                    newDay.isBefore(currentDay) -> 1
+                                    newDay.isAfter(currentDay) -> -1
+                                    else -> 0
+                                }
                             selectDay(
                                 coroutineScope,
                                 metricsViewModel,
                                 metricsState,
                                 personalityViewModel,
                                 context,
-                                startOfWeek.plusDays(index.toLong()),
+                                newDay,
                             )
                         },
                         testTag = DashboardModalTestTags.DAY_INDICATOR_PREFIX + index,
@@ -300,6 +310,7 @@ fun CalendarMonthView(
     modifier: Modifier = Modifier,
     shouldShowCalendarView: MutableState<Boolean>,
     goalsViewModel: IGoalsViewModel,
+    dayTransitionDirection: MutableIntState,
 ) {
     val kiwiColors = LocalKiwiColors.current
     val selectedMonth = remember { mutableStateOf(YearMonth.from(stringToDate(metricsState.date))) }
@@ -392,6 +403,7 @@ fun CalendarMonthView(
                 month = month,
                 personalityViewModel = personalityViewModel,
                 goalsViewModel = goalsViewModel,
+                dayTransitionDirection = dayTransitionDirection,
             )
         }
     }
@@ -410,6 +422,7 @@ fun CalendarMonth(
     month: YearMonth,
     shouldShowCalendarView: MutableState<Boolean>,
     goalsViewModel: IGoalsViewModel,
+    dayTransitionDirection: MutableIntState,
 ) {
     val startOfMonth = month.atDay(1)
     val endOfMonth = month.atEndOfMonth()
@@ -452,6 +465,7 @@ fun CalendarMonth(
                                 isSelected = stringToDate(metricsState.date) == dayDate,
                                 onClicked = {
                                     AudioManager.playSFX(context, R.raw.snd_ui_tap)
+                                    dayTransitionDirection.intValue = 0
                                     selectDay(
                                         coroutineScope,
                                         metricsViewModel,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
@@ -87,9 +87,10 @@ fun CurrentDayIndicator(
     size: Dp,
     dailyGoalsProgress: Float,
     appUsageProgress: Float,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier.size(size),
+        modifier = modifier.size(size),
     ) {
         Kiwi_Image(
             if (dailyGoalsProgress == 1f && appUsageProgress == 1f) {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
@@ -495,6 +495,7 @@ fun CalendarMonth(
     }
 }
 
+@Suppress("CyclomaticComplexMethod")
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
 fun CalendarDayView(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
@@ -253,8 +253,10 @@ fun CalendarWeekView(
                 val isSelected = selectedDayIndex == index
 
                 var dailyGoalProgress by remember { mutableFloatStateOf(0f) }
-                LaunchedEffect(Unit) {
+                var appUsageProgress by remember { mutableFloatStateOf(0f) }
+                LaunchedEffect(day, metricsState) {
                     dailyGoalProgress = goalsViewModel.getDailyGoalsProgress(day.toString())
+                    appUsageProgress = metricsViewModel.getAppUsageProgress(day.toString())
                 }
 
                 Box(modifier = Modifier.weight(1f)) {
@@ -285,7 +287,7 @@ fun CalendarWeekView(
                         },
                         testTag = DashboardModalTestTags.DAY_INDICATOR_PREFIX + index,
                         hasCompletedDailyGoals = dailyGoalProgress >= 1F,
-                        hasCompletedAppUsages = metricsState.getAppUsageProgress() >= 1F,
+                        hasCompletedAppUsages = appUsageProgress >= 1F,
                     )
                 }
             }
@@ -449,8 +451,10 @@ fun CalendarMonth(
                     val dayDate = startOfMonth.plusDays(dayOffset.toLong())
 
                     var dailyGoalProgress by remember { mutableFloatStateOf(0f) }
-                    LaunchedEffect(Unit) {
+                    var appUsageProgress by remember { mutableFloatStateOf(0f) }
+                    LaunchedEffect(dayDate, metricsState) {
                         dailyGoalProgress = goalsViewModel.getDailyGoalsProgress(dayDate.toString())
+                        appUsageProgress = metricsViewModel.getAppUsageProgress(dayDate.toString())
                     }
 
                     Box(
@@ -478,7 +482,7 @@ fun CalendarMonth(
                                 },
                                 testTag = DashboardModalTestTags.DAY_INDICATOR_PREFIX + dayDate.dayOfMonth,
                                 hasCompletedDailyGoals = dailyGoalProgress >= 1F,
-                                hasCompletedAppUsages = metricsState.getAppUsageProgress() >= 1F,
+                                hasCompletedAppUsages = appUsageProgress >= 1F,
                             )
                         } else {
                             Kiwi_Spacer()

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/dashboard/screens/DashboardScreen_Calendar.kt
@@ -490,16 +490,25 @@ fun CalendarDayView(
     testTag: String,
 ) {
     val kiwiColors = LocalKiwiColors.current
+    val isToday = day == LocalDate.now()
     val isDayEnabled =
         !day.isAfter(LocalDate.now()) &&
             (canSelectBeforeRegisterDate || !day.isBefore(usersViewModel.getRegisterDate()))
 
+    @Suppress("MagicNumber")
+    val todayBackground = kiwiColors.colorF.copy(alpha = 0.3f)
     Box(
         modifier =
             Modifier
                 .clip(RoundedCornerShape(getResponsiveSizeHeight(20.dp)))
-                .background(color = if (isSelected) kiwiColors.color9A else kiwiColors.color3A)
-                .border(
+                .background(
+                    color =
+                        when {
+                            isToday -> todayBackground
+                            isSelected -> kiwiColors.color9A
+                            else -> kiwiColors.color3A
+                        },
+                ).border(
                     width = if (isSelected) getResponsiveSizeHeight(2.dp) else 0.dp,
                     color = if (isSelected) kiwiColors.color9 else Color.Transparent,
                     shape = RoundedCornerShape(getResponsiveSizeHeight(20.dp)),
@@ -520,7 +529,12 @@ fun CalendarDayView(
             Kiwi_P2(
                 KiwiTextArguments(
                     day.dayOfMonth.toString(),
-                    color = if (isSelected) kiwiColors.color9 else kiwiColors.color4B,
+                    color =
+                        when {
+                            isToday -> kiwiColors.color0
+                            isSelected -> kiwiColors.color9
+                            else -> kiwiColors.color4B
+                        },
                 ),
             )
             Box(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/metrics/model/IMetricsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/metrics/model/IMetricsViewModel.kt
@@ -12,4 +12,6 @@ interface IMetricsViewModel : IBaseViewModel<MetricsState> {
     suspend fun updateMetrics(state: MetricsState): Result<Unit>
 
     suspend fun loadMetrics(date: String): Result<Unit>
+
+    suspend fun getAppUsageProgress(date: String): Float
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/metrics/model/MetricsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/metrics/model/MetricsViewModel.kt
@@ -76,4 +76,10 @@ class MetricsViewModel
                 _state.value = MetricsDataMapper.toState(result.getOrNull()!!)
             }
         }
+
+        @RequiresApi(Build.VERSION_CODES.O)
+        override suspend fun getAppUsageProgress(date: String): Float {
+            val dto = repository.getMetricsByDate(stringToDate(date)).getOrNull() ?: return 0f
+            return MetricsDataMapper.toState(dto).getAppUsageProgress()
+        }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/metrics/tests/MetricsFakeViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/metrics/tests/MetricsFakeViewModel.kt
@@ -73,4 +73,14 @@ class MetricsFakeViewModel(
 
             Result.success(Unit)
         }
+
+    override suspend fun getAppUsageProgress(date: String): Float {
+        val dto =
+            if (stringToDate(date).isEqual(currentDate)) {
+                todayMetricsDTO
+            } else {
+                pastMetricsDTO
+            }
+        return MetricsDataMapper.toState(dto).getAppUsageProgress()
+    }
 }


### PR DESCRIPTION
## Summary

This PR polishes the mobile dashboard with a full suite of Compose animations and several UX fixes. The three dashboard layout states (hidden/collapsed/expanded) now transition with animated crossfades and a shared-element heart indicator. Day switching drives directional horizontal slides, the dashboard itself slides in and out when conversations or combats appear, and chevron buttons let users step between layouts without dragging. Several accuracy and empty-state bugs are also fixed along the way.

## Changes

### Game Logic / Other

- **Dashboard show/hide animation**: Replaced the bare `if` guard with `AnimatedVisibility` (slide + fade, 400 ms, EaseInOut) so the dashboard animates in and out when conversations or combats overlap it.
- **Layout-switching chevrons**: Added `LayoutChevron` buttons to the dashboard header so users can manually step between the hidden, collapsed, and expanded states without dragging the bar.
- **Layout transition animation**: Wrapped the three dashboard states in `AnimatedContent` inside a `SharedTransitionLayout` (1 200 ms crossfade). The `CurrentDayIndicator` heart is a shared element that morphs smoothly between its 100 dp (collapsed) and 180 dp (expanded) sizes.
- **Day-switching animation**: Selecting a day in the week or month calendar now triggers a directional horizontal slide + fade (550 ms) on the selected-day text, day indicator, and progress box. Direction is inferred from whether the target day is before or after the current day; month-calendar taps use a plain crossfade (no slide direction).
- **Calendar / week toggle**: Wrapped the week ↔ month calendar swap in a `Crossfade` (550 ms).
- **DraggableBar easing**: Both programmatic `animateTo` calls now use an `EaseInOut` tween (600 ms) instead of the default spring. Fixed the state-index lookup to snap to the nearest state rather than the nearest *larger* state.
- **Per-day app-usage progress**: Calendar week and month views now fetch `appUsageProgress` per day via the new `IMetricsViewModel.getAppUsageProgress(date)` method, fixing icons that previously always reflected the currently loaded day's value.
- **"No Daily Challenges" placeholder**: Shown in the expanded summary card when the goals list is empty, replacing a blank gap.
- **Metric time fallback**: "No data" replaced with `parseTimeSeconds(0)` (displays "00:00") for visual consistency with other time fields.
- **Today indicator in calendar**: The current date cell gets a distinct background (`colorF` at 30 % alpha) and text color (`color0`) to make today visually identifiable at a glance.
- **Feathered horizontal edges**: `featherHorizontalEdges()` modifier applies a `BlendMode.DstIn` horizontal gradient to the day-indicator and progress-box rows in the expanded view.
- **`SelectedMetricsTime` label**: Optional `label` parameter adds a subtitle line above the metric row (used in the collapsed view for "Good Apps" / "Evil Apps").
- Renamed metric titles "Good Apps Time" → "Good Apps" and "Evil Apps Time" → "Evil Apps" for brevity.
- Bumped `STATE_HEIGHT_0` from 140 → 150 dp.

## Schema / Migration Notes

No schema changes.

## Testing

1. Launch the app and navigate to the main screen with the dashboard visible.
2. Start a conversation or combat — verify the dashboard slides down out of view and slides back up when it ends (400 ms).
3. Tap the chevron arrows in the dashboard header and confirm each step animates with a 1 200 ms crossfade; verify the heart indicator morphs between sizes.
4. In the expanded view, tap different days in the week strip and confirm the day text, heart, and progress box slide horizontally in the direction matching earlier/later days.
5. Tap days in the month calendar and confirm a crossfade occurs (no directional slide).
6. Toggle between week and month calendar views and confirm the crossfade transition.
7. Confirm the current date is highlighted distinctly in both week and month views.
8. Remove all daily challenges and confirm the "No Daily Challenges" placeholder appears in the expanded view.
9. In the week/month calendar, confirm app-usage icons reflect each day's actual data, not the current day's value.
10. In the collapsed view, confirm "Good Apps" and "Evil Apps" labels appear above the metric time rows.

## Related

None.