### PR TITLE
Improvement/loading screen

### DIFF
--- a/mobile/app/src/androidTest/java/com/bellako/kiwi/LoginScreenTest.kt
+++ b/mobile/app/src/androidTest/java/com/bellako/kiwi/LoginScreenTest.kt
@@ -3,8 +3,11 @@ package com.bellako.kiwi
 import android.annotation.SuppressLint
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -112,7 +115,9 @@ class LoginScreenTest {
         usersFakeViewModel.fakeError = false
 
         rule.onNodeWithTag(UsersTestTags.LOGIN_BUTTON).performClick()
-        Thread.sleep(500)
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule.onAllNodesWithTag(UsersTestTags.LOGIN_BUTTON).fetchSemanticsNodes().isEmpty()
+        }
         rule.onNodeWithTag(UsersTestTags.LOGIN_BUTTON).assertDoesNotExist()
     }
 
@@ -122,6 +127,16 @@ class LoginScreenTest {
         usersFakeViewModel.fakeException = createFakeHttpException(HTTP_UNAUTHORIZED)
 
         rule.onNodeWithTag(UsersTestTags.LOGIN_BUTTON).performClick()
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule
+                .onAllNodesWithTag(UsersTestTags.ERROR_TEXT)
+                .fetchSemanticsNodes()
+                .any { node ->
+                    node.config
+                        .getOrNull(SemanticsProperties.Text)
+                        ?.any { it.text.isNotEmpty() } == true
+                }
+        }
         rule.onNodeWithTag(UsersTestTags.ERROR_TEXT).assertIsDisplayed()
     }
 
@@ -131,6 +146,9 @@ class LoginScreenTest {
         usersFakeViewModel.fakeException = createFakeHttpException(HTTP_INTERNAL_ERROR)
 
         rule.onNodeWithTag(UsersTestTags.LOGIN_BUTTON).performClick()
+        rule.waitUntil(timeoutMillis = 5000) {
+            rule.onAllNodesWithTag(CommonTestTags.ERROR_MODAL).fetchSemanticsNodes().isNotEmpty()
+        }
         rule.onNodeWithTag(CommonTestTags.ERROR_MODAL).assertIsDisplayed()
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -162,8 +162,7 @@ private fun LoginLoadingContent(
     BoxWithConstraints(
         modifier =
             modifier
-                .fillMaxSize()
-                .background(Color.Black),
+                .fillMaxSize(),
     ) {
         val travelPx = constraints.maxHeight.toFloat()
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -1,15 +1,17 @@
 package com.bellako.kiwi.common.screens
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -21,10 +23,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,9 +47,14 @@ import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
+import kotlinx.coroutines.delay
 import kotlin.math.roundToInt
 
 const val LOGIN_LOADING_ANIM_DURATION_MS = 600
+
+private const val ELEMENT_ENTER_MS = 450
+private const val HOLD_BEFORE_EXIT_MS = 1500L
+private const val SPRITE_RISE_DIVISOR = 4
 
 private const val SPRITE_HEIGHT_DP = 400
 private const val SPRITE_OFFSET_X_DP = -50
@@ -53,152 +66,244 @@ private const val PERCENT_MULTIPLIER = 100
 private const val PROGRESS_TRACK_ALPHA = 0.25f
 private const val PROGRESS_BG_ALPHA = 0.7f
 
+/** Current animation state, snapshotted from the driving [Animatable]s each frame. */
+private data class LoadingAnim(
+    val enterOffset: Float,
+    val exitOffset: Float,
+    val spriteVisible: Boolean,
+    val dialogueVisible: Boolean,
+)
+
+private fun enterFrom(offsetY: (Int) -> Int): EnterTransition =
+    slideInVertically(initialOffsetY = offsetY, animationSpec = tween(ELEMENT_ENTER_MS, easing = EaseInOut)) +
+        fadeIn(animationSpec = tween(ELEMENT_ENTER_MS, easing = EaseInOut))
+
 @Composable
 fun LoginLoadingScreen(
     visible: Boolean,
     progress: Float = 0f,
     modifier: Modifier = Modifier,
 ) {
-    AnimatedVisibility(
-        modifier = modifier,
-        visible = visible,
-        enter =
-            slideInVertically(
-                initialOffsetY = { fullHeight -> fullHeight },
-                animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
-            ) +
-                fadeIn(
-                    animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
-                ),
-        exit =
-            slideOutVertically(
-                targetOffsetY = { fullHeight -> fullHeight },
-                animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
-            ) +
-                fadeOut(
-                    animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
-                ),
-    ) {
-        LoginLoadingContent(progress = progress)
+    var present by remember { mutableStateOf(false) }
+    var dismissRequested by remember { mutableStateOf(false) }
+    var entranceComplete by remember { mutableStateOf(false) }
+    var spriteVisible by remember { mutableStateOf(false) }
+    var dialogueVisible by remember { mutableStateOf(false) }
+
+    // Single shared offset (1 = one screen below, 0 = in place) that the background
+    // and the progress bar BOTH read, so they move as one linked unit on entry.
+    val enterOffset = remember { Animatable(1f) }
+    // Single container offset (0 = in place, 1 = one screen below) that slides the
+    // entire screen — every element together — down on exit.
+    val exitOffset = remember { Animatable(0f) }
+
+    LaunchedEffect(visible) {
+        if (visible) {
+            present = true
+            dismissRequested = false
+        } else {
+            dismissRequested = true
+        }
     }
+
+    // Keyed on `present` so a fast loading (visible flipping to false early)
+    // cannot cancel the entrance — it always plays in full.
+    LaunchedEffect(present) {
+        if (!present) return@LaunchedEffect
+        entranceComplete = false
+        spriteVisible = false
+        dialogueVisible = false
+        enterOffset.snapTo(1f)
+        exitOffset.snapTo(0f)
+        enterOffset.animateTo(0f, tween(LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut))
+        spriteVisible = true
+        delay(ELEMENT_ENTER_MS.toLong())
+        dialogueVisible = true
+        delay(ELEMENT_ENTER_MS.toLong())
+        entranceComplete = true
+    }
+
+    // Exit only starts once the entrance has fully played AND a dismiss was requested.
+    // Hold the fully-assembled screen briefly so it can be absorbed before sliding out.
+    LaunchedEffect(entranceComplete, dismissRequested) {
+        if (!entranceComplete || !dismissRequested) return@LaunchedEffect
+        delay(HOLD_BEFORE_EXIT_MS)
+        exitOffset.animateTo(1f, tween(LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut))
+        entranceComplete = false
+        present = false
+    }
+
+    if (!present) return
+
+    LoginLoadingContent(
+        progress = progress,
+        anim =
+            LoadingAnim(
+                enterOffset = enterOffset.value,
+                exitOffset = exitOffset.value,
+                spriteVisible = spriteVisible,
+                dialogueVisible = dialogueVisible,
+            ),
+        modifier = modifier,
+    )
 }
 
 @Composable
-private fun LoginLoadingContent(progress: Float) {
+@Suppress("LongMethod")
+private fun LoginLoadingContent(
+    progress: Float,
+    anim: LoadingAnim,
+    modifier: Modifier = Modifier,
+) {
     val kiwiColors = LocalKiwiColors.current
 
     val percent = (progress.coerceIn(0f, 1f) * PERCENT_MULTIPLIER).roundToInt()
 
-    Box(
+    BoxWithConstraints(
         modifier =
-            Modifier
+            modifier
                 .fillMaxSize()
                 .background(Color.Black),
     ) {
-        Kiwi_Image(
-            R.drawable.background_mindveil,
-            "Loading background",
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize(),
-        )
+        val travelPx = constraints.maxHeight.toFloat()
 
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            verticalArrangement = Arrangement.Bottom,
+        // The whole screen rides this one layer, so every element slides down
+        // together as a single linked unit on exit.
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        translationY = anim.exitOffset * travelPx
+                        alpha = 1f - anim.exitOffset
+                    },
         ) {
-            Box(
-                modifier =
-                    Modifier
-                        .height(getResponsiveSizeHeight(SPRITE_HEIGHT_DP.dp))
-                        .fillMaxWidth()
-                        .offset(
-                            x = getResponsiveSizeWidth(SPRITE_OFFSET_X_DP.dp),
-                            y = getResponsiveSizeHeight(SPRITE_OFFSET_Y_DP.dp),
-                        ),
-            ) {
-                Kiwi_Image(
-                    R.drawable.character_liria_base,
-                    "Liria",
-                )
-            }
+            // Background and the progress bar share `enterOffset`, so they move
+            // by the exact same pixels at the same time when entering.
+            val linkedEntry =
+                Modifier.graphicsLayer {
+                    translationY = anim.enterOffset * travelPx
+                    alpha = 1f - anim.enterOffset
+                }
 
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .background(
-                            Brush.verticalGradient(
-                                DIALOGUE_GRADIENT_START_STOP to Color.Transparent,
-                                DIALOGUE_GRADIENT_MID_STOP to kiwiColors.color2,
-                                DIALOGUE_GRADIENT_END_STOP to kiwiColors.color2,
-                            ),
-                        ),
+            Kiwi_Image(
+                R.drawable.background_mindveil,
+                "Loading background",
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize().then(linkedEntry),
+            )
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.Bottom,
             ) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier =
-                        Modifier.padding(
-                            horizontal = Spacing.medium,
-                            vertical = getResponsiveSizeHeight(Spacing.large),
-                        ),
+                AnimatedVisibility(
+                    visible = anim.spriteVisible,
+                    enter = enterFrom { fullHeight -> fullHeight / SPRITE_RISE_DIVISOR },
+                    exit = ExitTransition.None,
                 ) {
-                    Kiwi_Image(
-                        R.drawable.dialogue_light_medium,
-                        "Dialogue frame",
-                        contentScale = ContentScale.FillWidth,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Kiwi_P2(
-                        KiwiTextArguments(
-                            "We are loading your adventure, please stay put.",
-                            textAlign = TextAlign.Center,
-                            color = kiwiColors.color3,
-                            modifier = Modifier.padding(Spacing.medium, Spacing.medium),
-                        ),
-                    )
                     Box(
                         modifier =
                             Modifier
-                                .matchParentSize()
-                                .offset(x = getResponsiveSizeWidth(25.dp)),
+                                .height(getResponsiveSizeHeight(SPRITE_HEIGHT_DP.dp))
+                                .fillMaxWidth()
+                                .offset(
+                                    x = getResponsiveSizeWidth(SPRITE_OFFSET_X_DP.dp),
+                                    y = getResponsiveSizeHeight(SPRITE_OFFSET_Y_DP.dp),
+                                ),
                     ) {
-                        CharacterName("Liria", dark = false, small = false)
+                        Kiwi_Image(
+                            R.drawable.character_liria_base,
+                            "Liria",
+                        )
+                    }
+                }
+
+                AnimatedVisibility(
+                    visible = anim.dialogueVisible,
+                    enter = enterFrom { fullHeight -> fullHeight },
+                    exit = ExitTransition.None,
+                ) {
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .background(
+                                    Brush.verticalGradient(
+                                        DIALOGUE_GRADIENT_START_STOP to Color.Transparent,
+                                        DIALOGUE_GRADIENT_MID_STOP to kiwiColors.color2,
+                                        DIALOGUE_GRADIENT_END_STOP to kiwiColors.color2,
+                                    ),
+                                ),
+                    ) {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier =
+                                Modifier.padding(
+                                    horizontal = Spacing.medium,
+                                    vertical = getResponsiveSizeHeight(Spacing.large),
+                                ),
+                        ) {
+                            Kiwi_Image(
+                                R.drawable.dialogue_light_medium,
+                                "Dialogue frame",
+                                contentScale = ContentScale.FillWidth,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                            Kiwi_P2(
+                                KiwiTextArguments(
+                                    "We are loading your adventure, please stay put.",
+                                    textAlign = TextAlign.Center,
+                                    color = kiwiColors.color3,
+                                    modifier = Modifier.padding(Spacing.medium, Spacing.medium),
+                                ),
+                            )
+                            Box(
+                                modifier =
+                                    Modifier
+                                        .matchParentSize()
+                                        .offset(x = getResponsiveSizeWidth(25.dp)),
+                            ) {
+                                CharacterName("Liria", dark = false, small = false)
+                            }
+                        }
                     }
                 }
             }
-        }
 
-        Row(
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically,
-            modifier =
-                Modifier
-                    .align(Alignment.TopCenter)
-                    .fillMaxWidth()
-                    .padding(getResponsiveSizeHeight(Spacing.medium))
-                    .background(
-                        color = kiwiColors.color2.copy(alpha = PROGRESS_BG_ALPHA),
-                        shape = RoundedCornerShape(getResponsiveSizeHeight(Spacing.small)),
-                    ).padding(
-                        horizontal = getResponsiveSizeHeight(Spacing.medium),
-                        vertical = getResponsiveSizeHeight(Spacing.small),
-                    ),
-        ) {
-            LinearProgressIndicator(
-                progress = { progress },
-                modifier = Modifier.weight(1f),
-                color = kiwiColors.color6,
-                trackColor = kiwiColors.color6.copy(alpha = PROGRESS_TRACK_ALPHA),
-                strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
-            )
-            Kiwi_P2(
-                KiwiTextArguments(
-                    "$percent%",
-                    textAlign = TextAlign.Center,
+            Row(
+                horizontalArrangement = Arrangement.SpaceEvenly,
+                verticalAlignment = Alignment.CenterVertically,
+                modifier =
+                    Modifier
+                        .align(Alignment.TopCenter)
+                        .fillMaxWidth()
+                        .then(linkedEntry)
+                        .padding(getResponsiveSizeHeight(Spacing.medium))
+                        .background(
+                            color = kiwiColors.color2.copy(alpha = PROGRESS_BG_ALPHA),
+                            shape = RoundedCornerShape(getResponsiveSizeHeight(Spacing.small)),
+                        ).padding(
+                            horizontal = getResponsiveSizeHeight(Spacing.medium),
+                            vertical = getResponsiveSizeHeight(Spacing.small),
+                        ),
+            ) {
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.weight(1f),
                     color = kiwiColors.color6,
-                    modifier = Modifier.padding(start = Spacing.medium),
-                ),
-            )
+                    trackColor = kiwiColors.color6.copy(alpha = PROGRESS_TRACK_ALPHA),
+                    strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+                )
+                Kiwi_P2(
+                    KiwiTextArguments(
+                        "$percent%",
+                        textAlign = TextAlign.Center,
+                        color = kiwiColors.color6,
+                        modifier = Modifier.padding(start = Spacing.medium),
+                    ),
+                )
+            }
         }
     }
 }
@@ -209,6 +314,15 @@ private fun LoginLoadingContent(progress: Float) {
 @Composable
 fun LoginLoadingScreen_Preview() {
     Kiwi_Theme {
-        LoginLoadingContent(progress = 0.4f)
+        LoginLoadingContent(
+            progress = 0.4f,
+            anim =
+                LoadingAnim(
+                    enterOffset = 0f,
+                    exitOffset = 0f,
+                    spriteVisible = true,
+                    dialogueVisible = true,
+                ),
+        )
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -1,0 +1,56 @@
+package com.bellako.kiwi.common.screens
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.bellako.kiwi.common.screens.components.LoadingModal
+
+const val LOGIN_LOADING_ANIM_DURATION_MS = 600
+
+@Composable
+fun LoginLoadingScreen(
+    visible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedVisibility(
+        modifier = modifier,
+        visible = visible,
+        enter =
+            slideInVertically(
+                initialOffsetY = { fullHeight -> fullHeight },
+                animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
+            ) +
+                fadeIn(
+                    animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
+                ),
+        exit =
+            slideOutVertically(
+                targetOffsetY = { fullHeight -> fullHeight },
+                animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
+            ) +
+                fadeOut(
+                    animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
+                ),
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black),
+            contentAlignment = Alignment.Center,
+        ) {
+            LoadingModal(color = Color.White)
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -8,19 +8,55 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import com.bellako.kiwi.common.screens.components.LoadingModal
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.bellako.kiwi.R
+import com.bellako.kiwi.common.screens.components.KiwiTextArguments
+import com.bellako.kiwi.common.screens.components.Kiwi_Image
+import com.bellako.kiwi.common.screens.components.Kiwi_P2
+import com.bellako.kiwi.features.conversations.components.CharacterName
+import com.bellako.kiwi.ui.Kiwi_Theme
+import com.bellako.kiwi.ui.LocalKiwiColors
+import com.bellako.kiwi.ui.Spacing
+import com.bellako.kiwi.ui.getResponsiveSizeHeight
+import com.bellako.kiwi.ui.getResponsiveSizeWidth
+import kotlin.math.roundToInt
 
 const val LOGIN_LOADING_ANIM_DURATION_MS = 600
+
+private const val SPRITE_HEIGHT_DP = 400
+private const val SPRITE_OFFSET_X_DP = -50
+private const val SPRITE_OFFSET_Y_DP = 100
+private const val DIALOGUE_GRADIENT_START_STOP = -0.2f
+private const val DIALOGUE_GRADIENT_MID_STOP = 0.5f
+private const val DIALOGUE_GRADIENT_END_STOP = 1f
+private const val PERCENT_MULTIPLIER = 100
+private const val PROGRESS_TRACK_ALPHA = 0.25f
+private const val PROGRESS_BG_ALPHA = 0.7f
 
 @Composable
 fun LoginLoadingScreen(
     visible: Boolean,
+    progress: Float = 0f,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(
@@ -43,14 +79,136 @@ fun LoginLoadingScreen(
                     animationSpec = tween(durationMillis = LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut),
                 ),
     ) {
-        Box(
+        LoginLoadingContent(progress = progress)
+    }
+}
+
+@Composable
+private fun LoginLoadingContent(progress: Float) {
+    val kiwiColors = LocalKiwiColors.current
+
+    val percent = (progress.coerceIn(0f, 1f) * PERCENT_MULTIPLIER).roundToInt()
+
+    Box(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .background(Color.Black),
+    ) {
+        Kiwi_Image(
+            R.drawable.background_mindveil,
+            "Loading background",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Bottom,
+        ) {
+            Box(
+                modifier =
+                    Modifier
+                        .height(getResponsiveSizeHeight(SPRITE_HEIGHT_DP.dp))
+                        .fillMaxWidth()
+                        .offset(
+                            x = getResponsiveSizeWidth(SPRITE_OFFSET_X_DP.dp),
+                            y = getResponsiveSizeHeight(SPRITE_OFFSET_Y_DP.dp),
+                        ),
+            ) {
+                Kiwi_Image(
+                    R.drawable.character_liria_base,
+                    "Liria",
+                )
+            }
+
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(
+                            Brush.verticalGradient(
+                                DIALOGUE_GRADIENT_START_STOP to Color.Transparent,
+                                DIALOGUE_GRADIENT_MID_STOP to kiwiColors.color2,
+                                DIALOGUE_GRADIENT_END_STOP to kiwiColors.color2,
+                            ),
+                        ),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier =
+                        Modifier.padding(
+                            horizontal = Spacing.medium,
+                            vertical = getResponsiveSizeHeight(Spacing.large),
+                        ),
+                ) {
+                    Kiwi_Image(
+                        R.drawable.dialogue_light_medium,
+                        "Dialogue frame",
+                        contentScale = ContentScale.FillWidth,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Kiwi_P2(
+                        KiwiTextArguments(
+                            "We are loading your adventure, please stay put.",
+                            textAlign = TextAlign.Center,
+                            color = kiwiColors.color3,
+                            modifier = Modifier.padding(Spacing.medium, Spacing.medium),
+                        ),
+                    )
+                    Box(
+                        modifier =
+                            Modifier
+                                .matchParentSize()
+                                .offset(x = getResponsiveSizeWidth(25.dp)),
+                    ) {
+                        CharacterName("Liria", dark = false, small = false)
+                    }
+                }
+            }
+        }
+
+        Row(
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
             modifier =
                 Modifier
-                    .fillMaxSize()
-                    .background(Color.Black),
-            contentAlignment = Alignment.Center,
+                    .align(Alignment.TopCenter)
+                    .fillMaxWidth()
+                    .padding(getResponsiveSizeHeight(Spacing.medium))
+                    .background(
+                        color = kiwiColors.color2.copy(alpha = PROGRESS_BG_ALPHA),
+                        shape = RoundedCornerShape(getResponsiveSizeHeight(Spacing.small)),
+                    ).padding(
+                        horizontal = getResponsiveSizeHeight(Spacing.medium),
+                        vertical = getResponsiveSizeHeight(Spacing.small),
+                    ),
         ) {
-            LoadingModal(color = Color.White)
+            LinearProgressIndicator(
+                progress = { progress },
+                modifier = Modifier.weight(1f),
+                color = kiwiColors.color6,
+                trackColor = kiwiColors.color6.copy(alpha = PROGRESS_TRACK_ALPHA),
+                strokeCap = ProgressIndicatorDefaults.LinearStrokeCap,
+            )
+            Kiwi_P2(
+                KiwiTextArguments(
+                    "$percent%",
+                    textAlign = TextAlign.Center,
+                    color = kiwiColors.color6,
+                    modifier = Modifier.padding(start = Spacing.medium),
+                ),
+            )
         }
+    }
+}
+
+@Preview(name = "Small Phone", widthDp = 320, heightDp = 640)
+@Preview(name = "Medium Phone", widthDp = 392, heightDp = 800)
+@Preview(name = "Large Phone", widthDp = 480, heightDp = 900)
+@Composable
+fun LoginLoadingScreen_Preview() {
+    Kiwi_Theme {
+        LoginLoadingContent(progress = 0.4f)
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -22,9 +22,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.zIndex
@@ -88,6 +91,14 @@ import com.bellako.kiwi.features.users.screens.SignUpScreen1_Welcome
 import com.bellako.kiwi.features.users.screens.SignUpScreen2_Form
 import com.bellako.kiwi.features.users.screens.SignUpScreen3_Test
 import com.bellako.kiwi.features.users.screens.SignUpScreen4_Apps
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
+
+private const val INITIAL_LOADING_MIN_DISPLAY_MS = 1500L
+private const val INITIAL_LOADING_SETTLE_MS = 400L
+private const val INITIAL_LOADING_MAX_DISPLAY_MS = 15_000L
+private const val AUTH_CHECK_GRACE_MS = 200L
 
 @Suppress("LongParameterList")
 @RequiresApi(Build.VERSION_CODES.Q)
@@ -183,6 +194,58 @@ private fun AppScreen(
     val skillsState by skillsViewModel.state.collectAsState()
 
     val isTipVisible by tipsViewModel.isVisible.collectAsState()
+
+    val usersIsLoading by usersViewModel.isLoading.collectAsState()
+    val personalityIsLoading by personalityViewModel.isLoading.collectAsState()
+    val settingsIsLoading by settingsViewModel.isLoading.collectAsState()
+    val skillsIsLoading by skillsViewModel.isLoading.collectAsState()
+    val combatIsLoading by combatViewModel.isLoading.collectAsState()
+    val goalsIsLoading by goalsViewModel.isLoading.collectAsState()
+    val questsIsLoading by questsViewModel.isLoading.collectAsState()
+    val metricsIsLoading by metricsViewModel.isLoading.collectAsState()
+    val nodesIsLoading by nodesViewModel.isLoading.collectAsState()
+    val anyFeatureLoading by remember {
+        derivedStateOf {
+            usersIsLoading || personalityIsLoading || settingsIsLoading ||
+                skillsIsLoading || combatIsLoading || goalsIsLoading ||
+                questsIsLoading || metricsIsLoading || nodesIsLoading
+        }
+    }
+
+    val initialAuthCheckPerformed by usersViewModel.initialAuthCheckPerformed.collectAsState()
+    val manualAuthOverlayActive by usersViewModel.manualAuthOverlayActive.collectAsState()
+    var showInitialLoading by remember { mutableStateOf(true) }
+    val overlayVisible by remember {
+        derivedStateOf { showInitialLoading || manualAuthOverlayActive }
+    }
+
+    LaunchedEffect(isLoginCompleted) {
+        if (!isLoginCompleted) return@LaunchedEffect
+        showInitialLoading = true
+        delay(INITIAL_LOADING_MIN_DISPLAY_MS)
+        withTimeoutOrNull(INITIAL_LOADING_MAX_DISPLAY_MS) {
+            while (true) {
+                snapshotFlow { anyFeatureLoading }.first { !it }
+                val resumed =
+                    withTimeoutOrNull(INITIAL_LOADING_SETTLE_MS) {
+                        snapshotFlow { anyFeatureLoading }.first { it }
+                    }
+                if (resumed == null) break
+            }
+        }
+        showInitialLoading = false
+    }
+
+    LaunchedEffect(initialAuthCheckPerformed) {
+        if (!initialAuthCheckPerformed) return@LaunchedEffect
+        val authStarted =
+            withTimeoutOrNull(AUTH_CHECK_GRACE_MS) {
+                snapshotFlow { isLoginCompleted || usersIsLoading }.first { it }
+            }
+        if (authStarted == null) {
+            showInitialLoading = false
+        }
+    }
 
     LaunchedEffect(notificationManager) {
         notificationManager.notifications.collect { event ->
@@ -372,6 +435,14 @@ private fun AppScreen(
                 }
             }
         }
+
+        LoginLoadingScreen(
+            visible = overlayVisible,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .zIndex(100f),
+        )
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -5,7 +5,9 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -99,6 +101,9 @@ private const val INITIAL_LOADING_MIN_DISPLAY_MS = 1500L
 private const val INITIAL_LOADING_SETTLE_MS = 400L
 private const val INITIAL_LOADING_MAX_DISPLAY_MS = 15_000L
 private const val AUTH_CHECK_GRACE_MS = 200L
+private const val PROGRESS_FILL_DURATION_MS = 4500
+private const val PROGRESS_HOLD_TARGET = 0.9f
+private const val PROGRESS_FINISH_DURATION_MS = 300
 
 @Suppress("LongParameterList")
 @RequiresApi(Build.VERSION_CODES.Q)
@@ -244,6 +249,22 @@ private fun AppScreen(
             }
         if (authStarted == null) {
             showInitialLoading = false
+        }
+    }
+
+    val loadingProgress = remember { Animatable(0f) }
+    LaunchedEffect(overlayVisible) {
+        if (overlayVisible) {
+            loadingProgress.snapTo(0f)
+            loadingProgress.animateTo(
+                targetValue = PROGRESS_HOLD_TARGET,
+                animationSpec = tween(durationMillis = PROGRESS_FILL_DURATION_MS, easing = EaseOut),
+            )
+        } else if (loadingProgress.value > 0f && loadingProgress.value < 1f) {
+            loadingProgress.animateTo(
+                targetValue = 1f,
+                animationSpec = tween(durationMillis = PROGRESS_FINISH_DURATION_MS, easing = EaseInOut),
+            )
         }
     }
 
@@ -438,6 +459,7 @@ private fun AppScreen(
 
         LoginLoadingScreen(
             visible = overlayVisible,
+            progress = loadingProgress.value,
             modifier =
                 Modifier
                     .fillMaxSize()

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/settings/screens/SettingsScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/settings/screens/SettingsScreen.kt
@@ -64,9 +64,13 @@ import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
+import com.bellako.kiwi.common.screens.LOGIN_LOADING_ANIM_DURATION_MS
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+
+private const val LOGOUT_NAV_SETTLE_MS = 100L
 
 @Composable
 fun SettingsScreen(
@@ -316,10 +320,14 @@ private fun SettingsButtons(
                 color = kiwiColors.color5A,
                 onClick = {
                     CoroutineScope(Dispatchers.Main).launch {
+                        usersViewModel.setManualAuthOverlayActive(true)
+                        delay(LOGIN_LOADING_ANIM_DURATION_MS.toLong())
                         usersViewModel.logout(context)
                         navController.navigate(ScreenRoutes.LOGIN) {
                             popUpTo(ScreenRoutes.LOGIN) { inclusive = true }
                         }
+                        delay(LOGOUT_NAV_SETTLE_MS)
+                        usersViewModel.setManualAuthOverlayActive(false)
                     }
                 },
             )

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/model/IUsersViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/model/IUsersViewModel.kt
@@ -3,9 +3,18 @@ package com.bellako.kiwi.features.users.model
 import android.content.Context
 import com.bellako.kiwi.common.model.IBaseViewModel
 import com.bellako.kiwi.features.users.data.UsersState
+import kotlinx.coroutines.flow.StateFlow
 import java.time.LocalDate
 
 interface IUsersViewModel : IBaseViewModel<UsersState> {
+    val initialAuthCheckPerformed: StateFlow<Boolean>
+
+    val manualAuthOverlayActive: StateFlow<Boolean>
+
+    fun markInitialAuthCheckPerformed()
+
+    fun setManualAuthOverlayActive(active: Boolean)
+
     fun onEmailChanged(email: String)
 
     fun onPasswordChanged(password: String)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/model/UsersViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/model/UsersViewModel.kt
@@ -49,6 +49,20 @@ class UsersViewModel
         private val _isLoginCompleted = MutableStateFlow(false)
         val isLoginCompleted: StateFlow<Boolean> = _isLoginCompleted.asStateFlow()
 
+        private val _initialAuthCheckPerformed = MutableStateFlow(false)
+        override val initialAuthCheckPerformed: StateFlow<Boolean> = _initialAuthCheckPerformed.asStateFlow()
+
+        override fun markInitialAuthCheckPerformed() {
+            _initialAuthCheckPerformed.value = true
+        }
+
+        private val _manualAuthOverlayActive = MutableStateFlow(false)
+        override val manualAuthOverlayActive: StateFlow<Boolean> = _manualAuthOverlayActive.asStateFlow()
+
+        override fun setManualAuthOverlayActive(active: Boolean) {
+            _manualAuthOverlayActive.value = active
+        }
+
         init {
             repository.currentPoints
                 .onEach { points ->
@@ -121,6 +135,8 @@ class UsersViewModel
         override suspend fun logout(context: Context) {
             clearLocalCredentials(context)
             authRepository.setJwtToken("")
+            _isLoginCompleted.value = false
+            _initialAuthCheckPerformed.value = false
         }
 
         // -----------------------------------------------------------------------------------------

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/LogInScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/LogInScreen.kt
@@ -51,6 +51,7 @@ import com.bellako.kiwi.common.screens.components.Kiwi_InfoBox
 import com.bellako.kiwi.common.screens.components.Kiwi_InputField
 import com.bellako.kiwi.common.screens.components.Kiwi_Label2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
+import com.bellako.kiwi.common.screens.LOGIN_LOADING_ANIM_DURATION_MS
 import com.bellako.kiwi.common.screens.components.LoadingModal
 import com.bellako.kiwi.common.screens.modals.ErrorModalScreen
 import com.bellako.kiwi.features.personality.data.PersonalityState
@@ -68,6 +69,7 @@ import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
@@ -172,7 +174,10 @@ private fun LogInLayout(
         if (!username.isNullOrBlank() && !password.isNullOrBlank()) {
             usersViewModel.onEmailChanged(username)
             usersViewModel.onPasswordChanged(password)
+            usersViewModel.markInitialAuthCheckPerformed()
             localLoading = performLogin(context, usersViewModel, personalityViewModel, navController)
+        } else {
+            usersViewModel.markInitialAuthCheckPerformed()
         }
     }
 
@@ -286,9 +291,13 @@ private fun LogInForm(
             color = kiwiColors.color5,
             onClick = {
                 CoroutineScope(Dispatchers.Main).launch {
-                    if (performLogin(context, usersViewModel, personalityViewModel, navController)) {
+                    usersViewModel.setManualAuthOverlayActive(true)
+                    delay(LOGIN_LOADING_ANIM_DURATION_MS.toLong())
+                    val success = performLogin(context, usersViewModel, personalityViewModel, navController)
+                    if (success) {
                         onLoginSuccess()
                     }
+                    usersViewModel.setManualAuthOverlayActive(false)
                 }
             },
             enabled = !isLoading,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/tests/UsersFakeViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/tests/UsersFakeViewModel.kt
@@ -23,6 +23,20 @@ class UsersFakeViewModel(
     private val _state = MutableStateFlow<UsersState?>(initialState)
     override val state: StateFlow<UsersState?> = _state.asStateFlow()
 
+    private val _initialAuthCheckPerformed = MutableStateFlow(false)
+    override val initialAuthCheckPerformed: StateFlow<Boolean> = _initialAuthCheckPerformed.asStateFlow()
+
+    override fun markInitialAuthCheckPerformed() {
+        _initialAuthCheckPerformed.value = true
+    }
+
+    private val _manualAuthOverlayActive = MutableStateFlow(false)
+    override val manualAuthOverlayActive: StateFlow<Boolean> = _manualAuthOverlayActive.asStateFlow()
+
+    override fun setManualAuthOverlayActive(active: Boolean) {
+        _manualAuthOverlayActive.value = active
+    }
+
     var fakeError: Boolean = false
     var fakeException: Exception = Exception("Simulated error")
 


### PR DESCRIPTION
## Summary

Introduces a polished `LoginLoadingScreen` that covers the app during login and post-login data fetching, hiding UI pop-ins while all feature ViewModels hydrate. The overlay plays a multi-stage entrance animation (background + progress bar slide up, character sprite rises, dialogue box appears), holds until every ViewModel finishes loading, then exits by sliding the entire screen down as a single unit. The same overlay is reused for the logout flow so the navigation back to the login screen is also masked.

## Changes

### Game Logic / Other

- **`LoginLoadingScreen` (new)** — Compose screen with a three-phase animation: linked entry of the `background_mindveil` image and a `LinearProgressIndicator`, staggered `AnimatedVisibility` entrance for the Liria sprite and dialogue box, and a coordinated full-screen exit slide. Entrance always plays in full even if loading finishes early; exit is held until the entrance completes, then delayed briefly before sliding out.
- **`MainScreen`** — Collects `isLoading` from all nine feature ViewModels into a single `anyFeatureLoading` derived state. On login completion, the overlay shows for at least 1.5 s, then waits for all loaders to settle (with a 15 s safety timeout). An `initialAuthCheckPerformed` guard also collapses the overlay early when no login is in progress on cold start. A separate `Animatable` drives the progress bar from 0 → 90 % during loading, then snaps to 100 % on completion.
- **`SettingsScreen`** — Logout now activates the manual overlay before clearing credentials and navigating, then deactivates it after a short settle delay, so the screen transition is fully covered.
- **`LogInScreen`** — Login button press activates the manual overlay before calling `performLogin`, deactivates it after navigation regardless of success or failure.
- **`IUsersViewModel` / `UsersViewModel` / `UsersFakeViewModel`** — Added `initialAuthCheckPerformed` and `manualAuthOverlayActive` `StateFlow`s with corresponding control methods. `logout()` now resets both flags so the overlay behaves correctly on re-login.
- **`LoginScreenTest`** — Replaced `Thread.sleep` calls with `waitUntil` + semantics-node checks, eliminating timing-dependent flakiness in the login-success, 401, and 500 test cases.

## Schema / Migration Notes

No schema changes.

## Testing

1. Build and run the app on a physical device or emulator.
2. Log in — the loading screen should appear immediately, animate in Liria and the dialogue box, show a progress bar that fills to ~90 % and then jumps to 100 % when all data is ready, then slide the whole overlay down before revealing the main screen.
3. Navigate to Settings and log out — the loading screen should cover the transition back to the login screen.
4. Run the `LoginScreenTest` instrumented test suite and confirm all three tests pass reliably without `Thread.sleep` races.

## Related

None.