### PR TITLE
Improvement/UI components animations

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_Button.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_Button.kt
@@ -1,22 +1,24 @@
 package com.bellako.kiwi.common.screens.components
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -25,11 +27,14 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -49,6 +54,12 @@ import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+private const val KIWI_BUTTON_PRESSED_SCALE = 0.92f
+private const val KIWI_BUTTON_COLOR_DURATION_MS = 120
+private const val KIWI_BUTTON_PRESSED_DARKEN = 0.35f
+private const val KIWI_BUTTON_PRESSED_TEXT_LIGHTEN = 0.45f
 
 @Suppress("LongParameterList")
 @Composable
@@ -68,37 +79,90 @@ private fun Kiwi_Button(
     iconSpacer: Dp = Spacing.small,
 ) {
     val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    var pressed by remember { mutableStateOf(false) }
+    val scale = remember { Animatable(1f) }
+
+    val animatedColor by animateColorAsState(
+        targetValue =
+            if (pressed) lerp(color, Color.Black, KIWI_BUTTON_PRESSED_DARKEN) else color,
+        animationSpec = tween(durationMillis = KIWI_BUTTON_COLOR_DURATION_MS),
+        label = "buttonColor",
+    )
+
+    val animatedTextColor by animateColorAsState(
+        targetValue =
+            if (pressed) {
+                lerp(textArguments.color, Color.White, KIWI_BUTTON_PRESSED_TEXT_LIGHTEN)
+            } else {
+                textArguments.color
+            },
+        animationSpec = tween(durationMillis = KIWI_BUTTON_COLOR_DURATION_MS),
+        label = "buttonTextColor",
+    )
+
+    val containerColor =
+        if (enabled) animatedColor else color.copy(alpha = KIWI_DISABLED_ALPHA)
 
     Box(modifier) {
-        Button(
-            onClick = {
-                AudioManager.playSFX(context, sound)
-                onClick.invoke()
-            },
-            enabled = enabled,
-            colors =
-                ButtonDefaults.buttonColors(
-                    containerColor = color,
-                    disabledContainerColor = color.copy(alpha = KIWI_DISABLED_ALPHA),
-                    contentColor = color,
-                    disabledContentColor = color.copy(alpha = KIWI_DISABLED_ALPHA),
-                ),
-            contentPadding =
-                PaddingValues(
-                    getResponsiveSizeWidth(contentPaddingHorizontal),
-                    getResponsiveSizeWidth(contentPaddingVertical),
-                ),
+        Box(
             modifier =
                 Modifier
-                    .testTag(testTag)
                     .then(
                         horizontalMargin?.let {
                             Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = getResponsiveSizeWidth(it))
                         } ?: Modifier,
+                    )
+                    .graphicsLayer {
+                        scaleX = scale.value
+                        scaleY = scale.value
+                    }
+                    .clip(RoundedCornerShape(getResponsiveSizeHeight(12.dp)))
+                    .background(containerColor)
+                    .testTag(testTag)
+                    .pointerInput(enabled) {
+                        if (!enabled) return@pointerInput
+                        detectTapGestures(
+                            onPress = {
+                                pressed = true
+                                scope.launch {
+                                    scale.animateTo(
+                                        targetValue = KIWI_BUTTON_PRESSED_SCALE,
+                                        animationSpec = spring(stiffness = Spring.StiffnessHigh),
+                                    )
+                                }
+                                val released = tryAwaitRelease()
+                                pressed = false
+                                if (released) {
+                                    AudioManager.playSFX(context, sound)
+                                    scale.animateTo(
+                                        targetValue = 1f,
+                                        animationSpec =
+                                            spring(
+                                                dampingRatio = Spring.DampingRatioMediumBouncy,
+                                                stiffness = Spring.StiffnessMedium,
+                                            ),
+                                    )
+                                    onClick.invoke()
+                                } else {
+                                    scope.launch {
+                                        scale.animateTo(
+                                            targetValue = 1f,
+                                            animationSpec = spring(stiffness = Spring.StiffnessMedium),
+                                        )
+                                    }
+                                }
+                            },
+                        )
+                    }
+                    .padding(
+                        horizontal = getResponsiveSizeWidth(contentPaddingHorizontal),
+                        vertical = getResponsiveSizeWidth(contentPaddingVertical),
                     ),
-            shape = RoundedCornerShape(getResponsiveSizeHeight(12.dp)),
+            contentAlignment = Alignment.Center,
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -107,7 +171,12 @@ private fun Kiwi_Button(
                     Icon(
                         painter = painterResource(iconRes),
                         contentDescription = null,
-                        tint = textArguments.color,
+                        tint =
+                            if (enabled) {
+                                animatedTextColor
+                            } else {
+                                textArguments.color.copy(alpha = KIWI_DISABLED_ALPHA)
+                            },
                         modifier = Modifier.height(getResponsiveSizeHeight(iconSize)),
                     )
                     Kiwi_Spacer_Horizontal(iconSpacer)
@@ -115,7 +184,7 @@ private fun Kiwi_Button(
 
                 val actualTextArguments =
                     if (enabled) {
-                        textArguments
+                        textArguments.copy(color = animatedTextColor)
                     } else {
                         textArguments.copy(color = textArguments.color.copy(alpha = KIWI_DISABLED_ALPHA))
                     }
@@ -367,7 +436,7 @@ fun Kiwi_Button_Preview() {
                         color = kiwiColors.colorF,
                         fontWeight = FontWeight.Bold,
                     ),
-                color = kiwiColors.color5,
+                color = kiwiColors.color5A,
                 onClick = {},
             )
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_Button.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_Button.kt
@@ -1,7 +1,6 @@
 package com.bellako.kiwi.common.screens.components
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.animateFloatAsState
@@ -9,16 +8,20 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitFirstDown
-import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -27,7 +30,6 @@ import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -54,7 +56,6 @@ import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.launch
 
 private const val KIWI_BUTTON_PRESSED_SCALE = 0.92f
 private const val KIWI_BUTTON_COLOR_DURATION_MS = 120
@@ -79,10 +80,21 @@ private fun Kiwi_Button(
     iconSpacer: Dp = Spacing.small,
 ) {
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
+    val interactionSource = remember { MutableInteractionSource() }
+    val pressed by interactionSource.collectIsPressedAsState()
 
-    var pressed by remember { mutableStateOf(false) }
-    val scale = remember { Animatable(1f) }
+    // Pure composition-driven scale: pressed -> squish, released -> bouncy pop.
+    // animateFloatAsState (no Animatable/coroutine) keeps this race-free and
+    // deterministic under the Compose test clock.
+    val scale by animateFloatAsState(
+        targetValue = if (pressed) KIWI_BUTTON_PRESSED_SCALE else 1f,
+        animationSpec =
+            spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMedium,
+            ),
+        label = "buttonScale",
+    )
 
     val animatedColor by animateColorAsState(
         targetValue =
@@ -106,63 +118,40 @@ private fun Kiwi_Button(
         if (enabled) animatedColor else color.copy(alpha = KIWI_DISABLED_ALPHA)
 
     Box(modifier) {
-        Box(
+        Button(
+            onClick = {
+                AudioManager.playSFX(context, sound)
+                onClick.invoke()
+            },
+            enabled = enabled,
+            interactionSource = interactionSource,
+            colors =
+                ButtonDefaults.buttonColors(
+                    containerColor = containerColor,
+                    disabledContainerColor = color.copy(alpha = KIWI_DISABLED_ALPHA),
+                    contentColor = animatedTextColor,
+                    disabledContentColor = textArguments.color.copy(alpha = KIWI_DISABLED_ALPHA),
+                ),
+            contentPadding =
+                PaddingValues(
+                    getResponsiveSizeWidth(contentPaddingHorizontal),
+                    getResponsiveSizeWidth(contentPaddingVertical),
+                ),
             modifier =
                 Modifier
+                    .testTag(testTag)
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                    }
                     .then(
                         horizontalMargin?.let {
                             Modifier
                                 .fillMaxWidth()
                                 .padding(horizontal = getResponsiveSizeWidth(it))
                         } ?: Modifier,
-                    )
-                    .graphicsLayer {
-                        scaleX = scale.value
-                        scaleY = scale.value
-                    }
-                    .clip(RoundedCornerShape(getResponsiveSizeHeight(12.dp)))
-                    .background(containerColor)
-                    .testTag(testTag)
-                    .pointerInput(enabled) {
-                        if (!enabled) return@pointerInput
-                        detectTapGestures(
-                            onPress = {
-                                pressed = true
-                                scope.launch {
-                                    scale.animateTo(
-                                        targetValue = KIWI_BUTTON_PRESSED_SCALE,
-                                        animationSpec = spring(stiffness = Spring.StiffnessHigh),
-                                    )
-                                }
-                                val released = tryAwaitRelease()
-                                pressed = false
-                                if (released) {
-                                    AudioManager.playSFX(context, sound)
-                                    scale.animateTo(
-                                        targetValue = 1f,
-                                        animationSpec =
-                                            spring(
-                                                dampingRatio = Spring.DampingRatioMediumBouncy,
-                                                stiffness = Spring.StiffnessMedium,
-                                            ),
-                                    )
-                                    onClick.invoke()
-                                } else {
-                                    scope.launch {
-                                        scale.animateTo(
-                                            targetValue = 1f,
-                                            animationSpec = spring(stiffness = Spring.StiffnessMedium),
-                                        )
-                                    }
-                                }
-                            },
-                        )
-                    }
-                    .padding(
-                        horizontal = getResponsiveSizeWidth(contentPaddingHorizontal),
-                        vertical = getResponsiveSizeWidth(contentPaddingVertical),
                     ),
-            contentAlignment = Alignment.Center,
+            shape = RoundedCornerShape(getResponsiveSizeHeight(12.dp)),
         ) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_Slider.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/Kiwi_Slider.kt
@@ -1,5 +1,13 @@
 package com.bellako.kiwi.common.screens.components
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -8,10 +16,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -20,6 +32,20 @@ import com.bellako.kiwi.features.settings.tests.SettingsTestTags
 import com.bellako.kiwi.ui.Kiwi_Theme
 import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
+
+private const val KIWI_SLIDER_THUMB_ACTIVE_SCALE = 1.25f
+private const val KIWI_SLIDER_THUMB_DARKEN = 0.25f
+private const val KIWI_SLIDER_COLOR_DURATION_MS = 120
+private const val KIWI_SLIDER_PERCENT = 100f
+
+private fun formatSliderValue(
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+): String {
+    val span = valueRange.endInclusive - valueRange.start
+    val fraction = if (span > 0f) (value - valueRange.start) / span else 0f
+    return "${(fraction.coerceIn(0f, 1f) * KIWI_SLIDER_PERCENT).toInt()}%"
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -35,8 +61,38 @@ fun Kiwi_Slider(
     val kiwiColors = LocalKiwiColors.current
 
     if (textArguments != null) {
-        Kiwi_Label1(textArguments)
+        Kiwi_Label1(
+            textArguments.copy(
+                text = "${textArguments.text} (${formatSliderValue(value, valueRange)})",
+            ),
+        )
     }
+
+    val interactionSource = remember { MutableInteractionSource() }
+    val isPressed by interactionSource.collectIsPressedAsState()
+    val isDragged by interactionSource.collectIsDraggedAsState()
+    val active = isPressed || isDragged
+
+    val thumbScale by animateFloatAsState(
+        targetValue = if (active) KIWI_SLIDER_THUMB_ACTIVE_SCALE else 1f,
+        animationSpec =
+            spring(
+                dampingRatio = Spring.DampingRatioMediumBouncy,
+                stiffness = Spring.StiffnessMedium,
+            ),
+        label = "thumbScale",
+    )
+
+    val thumbColor by animateColorAsState(
+        targetValue =
+            if (active) {
+                lerp(kiwiColors.color7C, Color.Black, KIWI_SLIDER_THUMB_DARKEN)
+            } else {
+                kiwiColors.color7C
+            },
+        animationSpec = tween(durationMillis = KIWI_SLIDER_COLOR_DURATION_MS),
+        label = "thumbColor",
+    )
 
     Slider(
         value = value,
@@ -45,10 +101,16 @@ fun Kiwi_Slider(
         steps = steps,
         modifier = Modifier.fillMaxWidth().testTag(testTag).height(getResponsiveSizeHeight(40.dp)),
         enabled = enabled,
+        interactionSource = interactionSource,
         thumb = {
             Kiwi_Diamond(
                 size = getResponsiveSizeHeight(28.dp),
-                color = kiwiColors.color7C,
+                color = thumbColor,
+                modifier =
+                    Modifier.graphicsLayer {
+                        scaleX = thumbScale
+                        scaleY = thumbScale
+                    },
             )
         },
         track = { sliderState ->

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/appbar/screens/AppBarScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/appbar/screens/AppBarScreen.kt
@@ -6,8 +6,12 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -67,6 +71,9 @@ private const val NAV_ICON_POP_SCALE = 1.25f
 private const val NAV_ICON_POP_UP_MS = 110
 private const val NAV_ICON_PRESS_SCALE = 0.85f
 private const val NAV_ICON_PRESS_MS = 90
+private const val NAV_BADGE_PULSE_MAX_SCALE = 1.45f
+private const val NAV_BADGE_PULSE_MIN_ALPHA = 0.45f
+private const val NAV_BADGE_PULSE_MS = 650
 
 // -------------------------------------------------------------------------------------------------
 
@@ -241,10 +248,37 @@ private fun AppBarIcon(
             )
 
             if (showBadge) {
+                val pulse = rememberInfiniteTransition(label = "badgePulse")
+                val badgeScale by pulse.animateFloat(
+                    initialValue = 1f,
+                    targetValue = NAV_BADGE_PULSE_MAX_SCALE,
+                    animationSpec =
+                        infiniteRepeatable(
+                            animation = tween(NAV_BADGE_PULSE_MS, easing = EaseInOut),
+                            repeatMode = RepeatMode.Reverse,
+                        ),
+                    label = "badgeScale",
+                )
+                val badgeAlpha by pulse.animateFloat(
+                    initialValue = 1f,
+                    targetValue = NAV_BADGE_PULSE_MIN_ALPHA,
+                    animationSpec =
+                        infiniteRepeatable(
+                            animation = tween(NAV_BADGE_PULSE_MS, easing = EaseInOut),
+                            repeatMode = RepeatMode.Reverse,
+                        ),
+                    label = "badgeAlpha",
+                )
+
                 Box(
                     modifier =
                         Modifier
                             .size(getResponsiveSizeHeight(8.dp))
+                            .graphicsLayer {
+                                scaleX = badgeScale
+                                scaleY = badgeScale
+                                alpha = badgeAlpha
+                            }
                             .background(kiwiColors.color8A, CircleShape)
                             .align(Alignment.TopEnd),
                 )


### PR DESCRIPTION
## Summary

Adds tactile press animations to `Kiwi_Button` and `Kiwi_Slider`, and a pulsing indicator animation to the app bar notification badge. These changes improve perceived responsiveness and draw user attention to new content without requiring any backend or schema changes.

## Changes

### Game Logic / Other

- **`Kiwi_Button`** — Wires in a `MutableInteractionSource` to track press state. On press: the button squishes to 92 % scale with a bouncy spring release, the background darkens by 35 %, and the text/icon color lightens by 45 %. Disabled-state icon tinting is also corrected to use the proper alpha-reduced color.
- **`Kiwi_Slider`** — Wires in a `MutableInteractionSource` to track press and drag state. The thumb scales up to 125 % (bouncy spring) and darkens while active. Adds a `formatSliderValue()` helper that appends the current percentage to the slider label in real time.
- **`AppBarScreen`** — Adds an infinite `rememberInfiniteTransition` on the notification badge dot: it pulses between 1× and 1.45× scale and between full and 45 % alpha on a 650 ms ease-in-out loop whenever `showBadge` is true.

## Schema / Migration Notes

No schema changes.

## Testing

1. Build and run the app on a device or emulator.
2. Tap any `Kiwi_Button` — confirm the squish-and-bounce scale animation and the darkened background on press.
3. Interact with a `Kiwi_Slider` — confirm the thumb grows and darkens while pressed/dragged, and that the label shows the correct percentage.
4. Navigate to a screen where the app bar badge is visible — confirm the dot pulses continuously in scale and opacity.
5. Run the existing mobile test suite (`./gradlew :mobile:app:testDebugUnitTest`) — all animation tests should pass.

## Related

None.