### PR TITLE
Improvement/node animations

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -83,6 +83,7 @@ fun LoginLoadingScreen(
     visible: Boolean,
     progress: Float = 0f,
     modifier: Modifier = Modifier,
+    onExitComplete: () -> Unit = {},
 ) {
     var present by remember { mutableStateOf(false) }
     var dismissRequested by remember { mutableStateOf(false) }
@@ -131,6 +132,7 @@ fun LoginLoadingScreen(
         exitOffset.animateTo(1f, tween(LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut))
         entranceComplete = false
         present = false
+        onExitComplete()
     }
 
     if (!present) return

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -57,6 +58,9 @@ import com.bellako.kiwi.audio.Kiwi_Music_SignUp
 import com.bellako.kiwi.common.data.ScreenRoutes
 import com.bellako.kiwi.common.screens.modals.PermissionsModalScreen
 import com.bellako.kiwi.common.screens.modals.WIPModalScreen
+import com.bellako.kiwi.common.services.eventbus.EventBus
+import com.bellako.kiwi.common.services.eventbus.EventPayload
+import com.bellako.kiwi.common.services.eventbus.EventType
 import com.bellako.kiwi.features.appbar.model.AppBarViewModel
 import com.bellako.kiwi.features.appbar.screens.AppBarScreen
 import com.bellako.kiwi.features.combat.model.CombatViewModel
@@ -101,6 +105,7 @@ import com.bellako.kiwi.features.users.screens.SignUpScreen4_Apps
 import com.bellako.kiwi.ui.LocalKiwiColors
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 
 private const val INITIAL_LOADING_MIN_DISPLAY_MS = 1500L
@@ -298,6 +303,8 @@ private fun AppScreen(
 
     val goalsModalRequest = remember { mutableStateOf<Pair<GoalNotificationType, List<IGoal>>?>(null) }
 
+    val revealEventScope = rememberCoroutineScope()
+
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             containerColor = LocalKiwiColors.current.color2,
@@ -474,6 +481,11 @@ private fun AppScreen(
                 Modifier
                     .fillMaxSize()
                     .zIndex(100f),
+            onExitComplete = {
+                revealEventScope.launch {
+                    EventBus.emitEvent(EventType.MAP_REVEAL, EventPayload.EmptyPayload())
+                }
+            },
         )
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -79,6 +80,9 @@ import com.bellako.kiwi.features.map.screens.MapScreen
 import com.bellako.kiwi.features.metrics.model.MetricsViewModel
 import com.bellako.kiwi.features.nodes.model.INodesViewModel
 import com.bellako.kiwi.features.nodes.model.NodesViewModel
+import com.bellako.kiwi.features.nodes.screens.LocalNodeEntryTransition
+import com.bellako.kiwi.features.nodes.screens.NodeEntryWhiteoutOverlay
+import com.bellako.kiwi.features.nodes.screens.rememberNodeEntryTransitionController
 import com.bellako.kiwi.features.notifications.controller.NotificationEvent
 import com.bellako.kiwi.features.notifications.controller.NotificationManager
 import com.bellako.kiwi.features.notifications.screens.NotificationOverlay
@@ -305,6 +309,9 @@ private fun AppScreen(
 
     val revealEventScope = rememberCoroutineScope()
 
+    val nodeEntryTransition = rememberNodeEntryTransitionController()
+
+    CompositionLocalProvider(LocalNodeEntryTransition provides nodeEntryTransition) {
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
             containerColor = LocalKiwiColors.current.color2,
@@ -429,6 +436,15 @@ private fun AppScreen(
                     }
 
                     TipModal(isTipVisible, tipsViewModel)
+
+                    // White veil for the node-entry transition. Lives inside
+                    // the Scaffold's content area on purpose so it covers the
+                    // map / conversation / combat but leaves the bottom nav
+                    // bar visible.
+                    NodeEntryWhiteoutOverlay(
+                        controller = nodeEntryTransition,
+                        modifier = Modifier.zIndex(50f),
+                    )
                 }
             },
         )
@@ -487,6 +503,7 @@ private fun AppScreen(
                 }
             },
         )
+    }
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -81,7 +81,7 @@ import com.bellako.kiwi.features.metrics.model.MetricsViewModel
 import com.bellako.kiwi.features.nodes.model.INodesViewModel
 import com.bellako.kiwi.features.nodes.model.NodesViewModel
 import com.bellako.kiwi.features.nodes.screens.LocalNodeEntryTransition
-import com.bellako.kiwi.features.nodes.screens.NodeEntryWhiteoutOverlay
+import com.bellako.kiwi.features.nodes.screens.NodeEntryVeilOverlay
 import com.bellako.kiwi.features.nodes.screens.rememberNodeEntryTransitionController
 import com.bellako.kiwi.features.notifications.controller.NotificationEvent
 import com.bellako.kiwi.features.notifications.controller.NotificationManager
@@ -437,11 +437,11 @@ private fun AppScreen(
 
                     TipModal(isTipVisible, tipsViewModel)
 
-                    // White veil for the node-entry transition. Lives inside
-                    // the Scaffold's content area on purpose so it covers the
-                    // map / conversation / combat but leaves the bottom nav
-                    // bar visible.
-                    NodeEntryWhiteoutOverlay(
+                    // Veil for the node-entry transition. Lives inside the
+                    // Scaffold's content area on purpose so it covers the map
+                    // / conversation / combat but leaves the bottom nav bar
+                    // visible.
+                    NodeEntryVeilOverlay(
                         controller = nodeEntryTransition,
                         modifier = Modifier.zIndex(50f),
                     )

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/services/eventbus/Events.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/services/eventbus/Events.kt
@@ -16,6 +16,7 @@ enum class EventType {
     START_TIP,
     DAILY_GOALS_UPDATED,
     QUESTS_UPDATED,
+    MAP_REVEAL,
 }
 
 sealed class EventPayload {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBackground.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBackground.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -22,13 +23,16 @@ private const val EDGE_FADE_TOP_END = 0.18f
 private const val EDGE_FADE_BOTTOM_START = 0.55f
 
 @Composable
-internal fun CombatBackground(background: String?) {
+internal fun CombatBackground(
+    background: String?,
+    alpha: Float = 1f,
+) {
     val colors = LocalKiwiColors.current
     val resId = AssetResolver.drawable(LocalContext.current, background) ?: return
     Kiwi_Image(
         painterResourceId = resId,
         alt = "Combat background",
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxSize().alpha(alpha),
         contentScale = ContentScale.Crop,
         colorFilter =
             ColorFilter.colorMatrix(
@@ -39,6 +43,7 @@ internal fun CombatBackground(background: String?) {
         modifier =
             Modifier
                 .fillMaxSize()
+                .alpha(alpha)
                 .background(
                     Brush.verticalGradient(
                         0f to colors.color2.copy(alpha = EDGE_FADE_TOP_ALPHA),

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBattleArea.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBattleArea.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.zIndex
 import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.utils.AssetResolver
@@ -58,11 +59,15 @@ private const val ENEMY_DEFEAT_FADE_MS = 800
 private const val LOG_DIM_ALPHA = 0.55f
 
 @Composable
+@Suppress("LongParameterList")
 internal fun ColumnScope.CombatBattleArea(
     combat: CombatDomain,
     isLogOpen: Boolean,
     onDismissLog: () -> Unit,
     logEntries: List<CombatLogEntry>,
+    enemyBarRevealProgress: Float = 1f,
+    enemyBarNumbersAlpha: Float = 1f,
+    timerIntroProgress: Float = 1f,
 ) {
     Box(
         modifier =
@@ -74,6 +79,9 @@ internal fun ColumnScope.CombatBattleArea(
             currentHp = combat.enemy.stats.currentHp,
             maxHp = combat.enemy.stats.maxHp,
             endsAt = combat.endsAt,
+            barRevealProgress = enemyBarRevealProgress,
+            barNumbersAlpha = enemyBarNumbersAlpha,
+            timerIntroProgress = timerIntroProgress,
         )
 
         if (isLogOpen) {
@@ -102,12 +110,14 @@ internal fun ColumnScope.CombatBattleArea(
 }
 
 @Composable
+@Suppress("LongParameterList")
 internal fun CombatEnemySprite(
     enemySprite: String,
     currentHp: Int,
     isEnemyDefeated: Boolean,
     context: Context,
     modifier: Modifier = Modifier,
+    introAlpha: Float = 1f,
 ) {
     var previousHp by remember { mutableIntStateOf(currentHp) }
     var damageTrigger by remember { mutableIntStateOf(0) }
@@ -160,7 +170,7 @@ internal fun CombatEnemySprite(
             modifier
                 .fillMaxSize()
                 .offset { IntOffset(offsetX.value.roundToInt(), 0) }
-                .alpha(spriteAlpha.value),
+                .alpha(spriteAlpha.value * introAlpha),
         contentScale = ContentScale.Fit,
         colorFilter =
             if (redAlpha.value > 0f) {
@@ -175,10 +185,14 @@ internal fun CombatEnemySprite(
 }
 
 @Composable
+@Suppress("LongParameterList")
 private fun EnemyHud(
     currentHp: Int,
     maxHp: Int,
     endsAt: Long?,
+    barRevealProgress: Float = 1f,
+    barNumbersAlpha: Float = 1f,
+    timerIntroProgress: Float = 1f,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -190,13 +204,20 @@ private fun EnemyHud(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(getResponsiveSizeHeight(Spacing.xSmall)),
         ) {
+            // zIndex on the health bar so the timer below can render behind it
+            // during the intro slide-down.
             CombatHealthBar(
                 currentHp = currentHp,
                 maxHp = maxHp,
-                modifier = Modifier.fillMaxWidth(HEALTH_BAR_WIDTH_FRACTION),
+                modifier = Modifier.fillMaxWidth(HEALTH_BAR_WIDTH_FRACTION).zIndex(1f),
+                barRevealProgress = barRevealProgress,
+                numbersAlpha = barNumbersAlpha,
             )
 
-            CombatTimer(endsAt = endsAt)
+            CombatTimer(
+                endsAt = endsAt,
+                introProgress = timerIntroProgress,
+            )
         }
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatDeck.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatDeck.kt
@@ -3,11 +3,13 @@ package com.bellako.kiwi.features.combat.components
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.tooling.preview.Preview
 import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
@@ -24,12 +26,16 @@ private const val SKILL_WEIGHT = 0.5f
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
+@Suppress("LongParameterList")
 fun CombatDeck(
     deckSkills: List<SkillDomain>,
     isDisabled: Boolean,
     onSkillClick: (skillId: Long, skillName: String) -> Unit,
     onApplyGoalProgress: (skillId: Long, goalId: Long, newProgress: Int) -> Unit,
     modifier: Modifier = Modifier,
+    // Pop-scale per slot (0-indexed in slot order). Defaults to 1f so the deck
+    // renders unanimated outside the combat intro.
+    slotIntroScale: (slotIndex: Int) -> Float = { 1f },
 ) {
     val slotMap = deckSkills.associateBy { it.deckSlot }
 
@@ -41,20 +47,25 @@ fun CombatDeck(
             ) {
                 for (slot in rowStart..rowStart + 1) {
                     val skill = slotMap[slot]
-                    if (skill != null) {
-                        SkillComponent(
-                            skill = skill,
-                            isDisabled = isDisabled || skill.isCooldown,
-                            onClick = { onSkillClick(skill.id, skill.name) },
-                            modifier = Modifier.weight(SKILL_WEIGHT),
-                            onApplyGoalProgress = onApplyGoalProgress,
-                        )
-                    } else {
-                        Kiwi_Image(
-                            R.drawable.skill_empty,
-                            "Empty skill slot",
-                            modifier = Modifier.weight(SKILL_WEIGHT),
-                        )
+                    Box(
+                        modifier =
+                            Modifier
+                                .weight(SKILL_WEIGHT)
+                                .scale(slotIntroScale(slot - 1)),
+                    ) {
+                        if (skill != null) {
+                            SkillComponent(
+                                skill = skill,
+                                isDisabled = isDisabled || skill.isCooldown,
+                                onClick = { onSkillClick(skill.id, skill.name) },
+                                onApplyGoalProgress = onApplyGoalProgress,
+                            )
+                        } else {
+                            Kiwi_Image(
+                                R.drawable.skill_empty,
+                                "Empty skill slot",
+                            )
+                        }
                     }
                 }
             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatDeck.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatDeck.kt
@@ -3,12 +3,12 @@ package com.bellako.kiwi.features.combat.components
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.tooling.preview.Preview
 import com.bellako.kiwi.R
@@ -33,9 +33,12 @@ fun CombatDeck(
     onSkillClick: (skillId: Long, skillName: String) -> Unit,
     onApplyGoalProgress: (skillId: Long, goalId: Long, newProgress: Int) -> Unit,
     modifier: Modifier = Modifier,
-    // Pop-scale per slot (0-indexed in slot order). Defaults to 1f so the deck
-    // renders unanimated outside the combat intro.
+    // Pop scale per slot (0-indexed). Stays > 0 even before the slot's pop
+    // starts so the slot's layout bounds remain positive — the matching
+    // `slotIntroAlpha` is what hides it visually.
     slotIntroScale: (slotIndex: Int) -> Float = { 1f },
+    // Fade-in alpha per slot (0-indexed). Defaults to 1f.
+    slotIntroAlpha: (slotIndex: Int) -> Float = { 1f },
 ) {
     val slotMap = deckSkills.associateBy { it.deckSlot }
 
@@ -47,25 +50,25 @@ fun CombatDeck(
             ) {
                 for (slot in rowStart..rowStart + 1) {
                     val skill = slotMap[slot]
-                    Box(
-                        modifier =
-                            Modifier
-                                .weight(SKILL_WEIGHT)
-                                .scale(slotIntroScale(slot - 1)),
-                    ) {
-                        if (skill != null) {
-                            SkillComponent(
-                                skill = skill,
-                                isDisabled = isDisabled || skill.isCooldown,
-                                onClick = { onSkillClick(skill.id, skill.name) },
-                                onApplyGoalProgress = onApplyGoalProgress,
-                            )
-                        } else {
-                            Kiwi_Image(
-                                R.drawable.skill_empty,
-                                "Empty skill slot",
-                            )
-                        }
+                    val slotMod =
+                        Modifier
+                            .weight(SKILL_WEIGHT)
+                            .scale(slotIntroScale(slot - 1))
+                            .alpha(slotIntroAlpha(slot - 1))
+                    if (skill != null) {
+                        SkillComponent(
+                            skill = skill,
+                            isDisabled = isDisabled || skill.isCooldown,
+                            onClick = { onSkillClick(skill.id, skill.name) },
+                            modifier = slotMod,
+                            onApplyGoalProgress = onApplyGoalProgress,
+                        )
+                    } else {
+                        Kiwi_Image(
+                            R.drawable.skill_empty,
+                            "Empty skill slot",
+                            modifier = slotMod,
+                        )
                     }
                 }
             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatHealthBar.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatHealthBar.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
@@ -31,12 +32,19 @@ import com.bellako.kiwi.ui.LocalKiwiColors
 private const val HP_LERP_DURATION_MS = 600
 
 @Composable
+@Suppress("LongParameterList")
 fun CombatHealthBar(
     currentHp: Int,
     maxHp: Int,
     modifier: Modifier = Modifier,
     fillTint: Color? = null,
     label: String = "HP bar",
+    // 0f = bar hidden, 1f = fully revealed. The reveal grows from the centre
+    // outward toward both edges, used by the combat intro to introduce the bar.
+    barRevealProgress: Float = 1f,
+    // Independent alpha for the HP numbers so they can fade in after the bar
+    // graphic has finished its reveal.
+    numbersAlpha: Float = 1f,
 ) {
     val colors = LocalKiwiColors.current
     val animatedHp by animateIntAsState(
@@ -55,33 +63,47 @@ fun CombatHealthBar(
         modifier = modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center,
     ) {
-        Kiwi_Image(
-            painterResourceId = R.drawable.health_bar_bg,
-            alt = "$label background",
-            modifier = Modifier.fillMaxWidth(),
-            contentScale = ContentScale.FillWidth,
-        )
-
-        Kiwi_Image(
-            painterResourceId = R.drawable.health_bar_fill,
-            alt = "$label fill",
+        Box(
             modifier =
                 Modifier
                     .fillMaxWidth()
                     .graphicsLayer {
                         clip = true
-                        shape =
-                            object : Shape {
-                                override fun createOutline(
-                                    size: Size,
-                                    layoutDirection: LayoutDirection,
-                                    density: Density,
-                                ): Outline = Outline.Rectangle(Rect(0f, 0f, size.width * percentage, size.height))
-                            }
+                        shape = centerExpandShape(barRevealProgress)
                     },
-            contentScale = ContentScale.FillWidth,
-            colorFilter = fillTint?.let { ColorFilter.tint(it) },
-        )
+            contentAlignment = Alignment.Center,
+        ) {
+            Kiwi_Image(
+                painterResourceId = R.drawable.health_bar_bg,
+                alt = "$label background",
+                modifier = Modifier.fillMaxWidth(),
+                contentScale = ContentScale.FillWidth,
+            )
+
+            Kiwi_Image(
+                painterResourceId = R.drawable.health_bar_fill,
+                alt = "$label fill",
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .graphicsLayer {
+                            clip = true
+                            shape =
+                                object : Shape {
+                                    override fun createOutline(
+                                        size: Size,
+                                        layoutDirection: LayoutDirection,
+                                        density: Density,
+                                    ): Outline =
+                                        Outline.Rectangle(
+                                            Rect(0f, 0f, size.width * percentage, size.height),
+                                        )
+                                }
+                        },
+                contentScale = ContentScale.FillWidth,
+                colorFilter = fillTint?.let { ColorFilter.tint(it) },
+            )
+        }
 
         Kiwi_Label3(
             KiwiTextArguments(
@@ -89,10 +111,30 @@ fun CombatHealthBar(
                 color = colors.colorF,
                 textAlign = TextAlign.Center,
                 fontWeight = FontWeight.Bold,
+                modifier = Modifier.alpha(numbersAlpha),
             ),
         )
     }
 }
+
+/**
+ * Outline that exposes a horizontally centred slice of the bar whose width
+ * grows from 0 at [progress] = 0 to the full bar width at [progress] = 1. Used
+ * to reveal the health bar from the centre outward during the combat intro.
+ */
+private fun centerExpandShape(progress: Float): Shape =
+    object : Shape {
+        override fun createOutline(
+            size: Size,
+            layoutDirection: LayoutDirection,
+            density: Density,
+        ): Outline {
+            val visibleWidth = size.width * progress.coerceIn(0f, 1f)
+            val left = (size.width - visibleWidth) / 2f
+            val right = left + visibleWidth
+            return Outline.Rectangle(Rect(left, 0f, right, size.height))
+        }
+    }
 
 @Preview(name = "Medium Phone", widthDp = 392, heightDp = 100)
 @Composable

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatIntro.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatIntro.kt
@@ -24,6 +24,13 @@ private const val SKILL_POP_MS = 550
 private const val SKILL_STAGGER_MS = 220
 private const val TURN_INDICATOR_FADE_MS = 550
 
+// Minimum scale a deck slot keeps before its pop starts. Kept above zero so
+// the slot retains positive boundsInWindow — UI tests that assert
+// `isDisplayed` aren't blocked by a scale-0 graphicsLayer transform. The slot
+// is faded with `skillSlotAlpha` separately, so this tiny base scale is
+// visually invisible at intro-start.
+private const val SKILL_SLOT_MIN_SCALE = 0.5f
+
 // Breath between stages so the sequence reads as a series of beats rather than
 // one continuous slide.
 private const val STAGE_GAP_MS = 350L
@@ -123,11 +130,23 @@ class CombatIntroController internal constructor(
         isCompleted = true
     }
 
-    /** Pop scale for a deck slot (0-indexed), driven by [skillClockMs]. */
+    /**
+     * Pop scale for a deck slot (0-indexed), driven by [skillClockMs]. Stays
+     * at [SKILL_SLOT_MIN_SCALE] until the slot's stagger kicks in so the
+     * layout bounds are never collapsed to a point — pair with [skillSlotAlpha]
+     * for the actual visibility.
+     */
     fun skillSlotScale(slotIndex: Int): Float {
         val itemStart = slotIndex * SKILL_STAGGER_MS
         val rawP = ((skillClockMs - itemStart) / SKILL_POP_MS).coerceIn(0f, 1f)
-        return if (rawP <= 0f) 0f else EaseOutBack.transform(rawP).coerceAtLeast(0f)
+        val curve = if (rawP <= 0f) 0f else EaseOutBack.transform(rawP).coerceAtLeast(0f)
+        return SKILL_SLOT_MIN_SCALE + (1f - SKILL_SLOT_MIN_SCALE) * curve
+    }
+
+    /** Fade-in alpha for a deck slot (0-indexed), in lockstep with [skillSlotScale]. */
+    fun skillSlotAlpha(slotIndex: Int): Float {
+        val itemStart = slotIndex * SKILL_STAGGER_MS
+        return ((skillClockMs - itemStart) / SKILL_POP_MS).coerceIn(0f, 1f)
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatIntro.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatIntro.kt
@@ -1,0 +1,163 @@
+package com.bellako.kiwi.features.combat.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.EaseOutBack
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+
+// Per-stage timings for the combat intro. Tweak here to adjust pacing.
+private const val BG_FADE_MS = 1_100
+private const val ENEMY_FADE_MS = 1_100
+private const val HEALTH_MASK_MS = 700
+private const val HEALTH_NUMBERS_FADE_MS = 500
+private const val TIMER_SLIDE_MS = 700
+private const val SKILL_POP_MS = 550
+private const val SKILL_STAGGER_MS = 220
+private const val TURN_INDICATOR_FADE_MS = 550
+
+// Breath between stages so the sequence reads as a series of beats rather than
+// one continuous slide.
+private const val STAGE_GAP_MS = 350L
+private const val SUB_STAGE_GAP_MS = 180L
+
+/**
+ * Centralised animation state for the combat intro. Each stage exposes a
+ * `Float` (0f → 1f, or 0f → totalMs for the skills clock) that components read
+ * to drive their own piece of the entrance. The intro runs sequentially in
+ * [play], and individual stages can be skipped instantly by calling [snapToEnd].
+ *
+ * Defaults at construction time are 0f, so until [play] runs, nothing is
+ * visible — that's how the screen starts blank under the node-entry white
+ * veil. After [play] completes everything sits at 1f / max clock and reads as
+ * a fully-presented combat layout.
+ */
+@Stable
+class CombatIntroController internal constructor(
+    private val backgroundAlphaAnim: Animatable<Float, AnimationVector1D>,
+    private val enemyAlphaAnim: Animatable<Float, AnimationVector1D>,
+    private val enemyHealthMaskAnim: Animatable<Float, AnimationVector1D>,
+    private val enemyHealthNumbersAnim: Animatable<Float, AnimationVector1D>,
+    private val timerSlideAnim: Animatable<Float, AnimationVector1D>,
+    private val skillClockAnim: Animatable<Float, AnimationVector1D>,
+    private val playerHealthMaskAnim: Animatable<Float, AnimationVector1D>,
+    private val playerHealthNumbersAnim: Animatable<Float, AnimationVector1D>,
+    private val turnIndicatorAnim: Animatable<Float, AnimationVector1D>,
+) {
+    val backgroundAlpha: Float get() = backgroundAlphaAnim.value
+    val enemyAlpha: Float get() = enemyAlphaAnim.value
+    val enemyHealthMaskProgress: Float get() = enemyHealthMaskAnim.value
+    val enemyHealthNumbersAlpha: Float get() = enemyHealthNumbersAnim.value
+    val timerSlideProgress: Float get() = timerSlideAnim.value
+    val skillClockMs: Float get() = skillClockAnim.value
+    val playerHealthMaskProgress: Float get() = playerHealthMaskAnim.value
+    val playerHealthNumbersAlpha: Float get() = playerHealthNumbersAnim.value
+    val turnIndicatorAlpha: Float get() = turnIndicatorAnim.value
+
+    /** True once [play] has settled. Use to gate UI that should only appear
+     * after the intro is over (e.g. enemy barks). */
+    var isCompleted: Boolean by mutableStateOf(false)
+        private set
+
+    /**
+     * Plays the full intro sequence. Suspends until everything has settled.
+     * [onBackgroundShown] fires the moment the background fade-in completes —
+     * that's when the caller can safely dismiss any cover (e.g. the node-entry
+     * white veil) without the player glimpsing what's behind.
+     */
+    suspend fun play(
+        skillSlotCount: Int,
+        onBackgroundShown: () -> Unit = {},
+    ) {
+        isCompleted = false
+        backgroundAlphaAnim.animateTo(1f, tween(BG_FADE_MS, easing = LinearEasing))
+        onBackgroundShown()
+        delay(STAGE_GAP_MS)
+
+        enemyAlphaAnim.animateTo(1f, tween(ENEMY_FADE_MS, easing = LinearEasing))
+        delay(STAGE_GAP_MS)
+
+        enemyHealthMaskAnim.animateTo(1f, tween(HEALTH_MASK_MS, easing = FastOutSlowInEasing))
+        delay(SUB_STAGE_GAP_MS)
+        enemyHealthNumbersAnim.animateTo(1f, tween(HEALTH_NUMBERS_FADE_MS, easing = LinearEasing))
+        delay(STAGE_GAP_MS)
+
+        timerSlideAnim.animateTo(1f, tween(TIMER_SLIDE_MS, easing = FastOutSlowInEasing))
+        delay(STAGE_GAP_MS)
+
+        val skillTotalMs = skillStaggerTotalMs(skillSlotCount)
+        skillClockAnim.animateTo(
+            targetValue = skillTotalMs.toFloat(),
+            animationSpec = tween(skillTotalMs, easing = LinearEasing),
+        )
+        delay(STAGE_GAP_MS)
+
+        playerHealthMaskAnim.animateTo(1f, tween(HEALTH_MASK_MS, easing = FastOutSlowInEasing))
+        delay(SUB_STAGE_GAP_MS)
+        playerHealthNumbersAnim.animateTo(1f, tween(HEALTH_NUMBERS_FADE_MS, easing = LinearEasing))
+        delay(STAGE_GAP_MS)
+
+        turnIndicatorAnim.animateTo(1f, tween(TURN_INDICATOR_FADE_MS, easing = LinearEasing))
+        isCompleted = true
+    }
+
+    /** Snaps every stage to its final value, e.g. when previewing without animation. */
+    suspend fun snapToEnd(skillSlotCount: Int) {
+        backgroundAlphaAnim.snapTo(1f)
+        enemyAlphaAnim.snapTo(1f)
+        enemyHealthMaskAnim.snapTo(1f)
+        enemyHealthNumbersAnim.snapTo(1f)
+        timerSlideAnim.snapTo(1f)
+        skillClockAnim.snapTo(skillStaggerTotalMs(skillSlotCount).toFloat())
+        playerHealthMaskAnim.snapTo(1f)
+        playerHealthNumbersAnim.snapTo(1f)
+        turnIndicatorAnim.snapTo(1f)
+        isCompleted = true
+    }
+
+    /** Pop scale for a deck slot (0-indexed), driven by [skillClockMs]. */
+    fun skillSlotScale(slotIndex: Int): Float {
+        val itemStart = slotIndex * SKILL_STAGGER_MS
+        val rawP = ((skillClockMs - itemStart) / SKILL_POP_MS).coerceIn(0f, 1f)
+        return if (rawP <= 0f) 0f else EaseOutBack.transform(rawP).coerceAtLeast(0f)
+    }
+}
+
+@Composable
+fun rememberCombatIntroController(): CombatIntroController {
+    val bg = remember { Animatable(0f) }
+    val enemy = remember { Animatable(0f) }
+    val enemyMask = remember { Animatable(0f) }
+    val enemyNums = remember { Animatable(0f) }
+    val timer = remember { Animatable(0f) }
+    val skills = remember { Animatable(0f) }
+    val playerMask = remember { Animatable(0f) }
+    val playerNums = remember { Animatable(0f) }
+    val turn = remember { Animatable(0f) }
+    return remember {
+        CombatIntroController(
+            backgroundAlphaAnim = bg,
+            enemyAlphaAnim = enemy,
+            enemyHealthMaskAnim = enemyMask,
+            enemyHealthNumbersAnim = enemyNums,
+            timerSlideAnim = timer,
+            skillClockAnim = skills,
+            playerHealthMaskAnim = playerMask,
+            playerHealthNumbersAnim = playerNums,
+            turnIndicatorAnim = turn,
+        )
+    }
+}
+
+private fun skillStaggerTotalMs(slotCount: Int): Int {
+    if (slotCount <= 0) return SKILL_POP_MS
+    return SKILL_POP_MS + (slotCount - 1) * SKILL_STAGGER_MS
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatIntro.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatIntro.kt
@@ -12,17 +12,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 // Per-stage timings for the combat intro. Tweak here to adjust pacing.
-private const val BG_FADE_MS = 1_100
-private const val ENEMY_FADE_MS = 1_100
-private const val HEALTH_MASK_MS = 700
-private const val HEALTH_NUMBERS_FADE_MS = 500
-private const val TIMER_SLIDE_MS = 700
-private const val SKILL_POP_MS = 550
-private const val SKILL_STAGGER_MS = 220
-private const val TURN_INDICATOR_FADE_MS = 550
+private const val BG_FADE_MS = 800
+private const val ENEMY_FADE_MS = 700
+private const val HEALTH_MASK_MS = 500
+private const val HEALTH_NUMBERS_FADE_MS = 350
+private const val TIMER_SLIDE_MS = 500
+private const val SKILL_POP_MS = 400
+private const val SKILL_STAGGER_MS = 150
+private const val TURN_INDICATOR_FADE_MS = 400
 
 // Minimum scale a deck slot keeps before its pop starts. Kept above zero so
 // the slot retains positive boundsInWindow — UI tests that assert
@@ -31,10 +33,11 @@ private const val TURN_INDICATOR_FADE_MS = 550
 // visually invisible at intro-start.
 private const val SKILL_SLOT_MIN_SCALE = 0.5f
 
-// Breath between stages so the sequence reads as a series of beats rather than
-// one continuous slide.
-private const val STAGE_GAP_MS = 350L
-private const val SUB_STAGE_GAP_MS = 180L
+// Breath between intro groups so each phase reads as its own beat. The
+// sub-stage gap separates the bar reveal from the numbers fade within a
+// single health bar.
+private const val GROUP_GAP_MS = 200L
+private const val SUB_STAGE_GAP_MS = 100L
 
 /**
  * Centralised animation state for the combat intro. Each stage exposes a
@@ -43,9 +46,9 @@ private const val SUB_STAGE_GAP_MS = 180L
  * [play], and individual stages can be skipped instantly by calling [snapToEnd].
  *
  * Defaults at construction time are 0f, so until [play] runs, nothing is
- * visible — that's how the screen starts blank under the node-entry white
- * veil. After [play] completes everything sits at 1f / max clock and reads as
- * a fully-presented combat layout.
+ * visible — that's how the screen starts blank under the node-entry veil.
+ * After [play] completes everything sits at 1f / max clock and reads as a
+ * fully-presented combat layout.
  */
 @Stable
 class CombatIntroController internal constructor(
@@ -75,45 +78,70 @@ class CombatIntroController internal constructor(
         private set
 
     /**
-     * Plays the full intro sequence. Suspends until everything has settled.
+     * Plays the full intro sequence in three groups: (1) background alone,
+     * (2) enemy + its health bar + timer in parallel, (3) turn indicator +
+     * player skills + player health bar in parallel. Within a single health
+     * bar the mask reveal still precedes the numbers fade so the values don't
+     * pop in over a half-revealed bar.
+     *
      * [onBackgroundShown] fires the moment the background fade-in completes —
      * that's when the caller can safely dismiss any cover (e.g. the node-entry
-     * white veil) without the player glimpsing what's behind.
+     * veil) without the player glimpsing what's behind.
      */
     suspend fun play(
         skillSlotCount: Int,
         onBackgroundShown: () -> Unit = {},
     ) {
         isCompleted = false
+
+        // Group 1 — background fades in alone.
         backgroundAlphaAnim.animateTo(1f, tween(BG_FADE_MS, easing = LinearEasing))
         onBackgroundShown()
-        delay(STAGE_GAP_MS)
+        delay(GROUP_GAP_MS)
 
-        enemyAlphaAnim.animateTo(1f, tween(ENEMY_FADE_MS, easing = LinearEasing))
-        delay(STAGE_GAP_MS)
+        // Group 2 — enemy sprite, enemy health bar (mask → numbers), and timer
+        // slide all play together.
+        coroutineScope {
+            launch {
+                enemyAlphaAnim.animateTo(1f, tween(ENEMY_FADE_MS, easing = LinearEasing))
+            }
+            launch { animateHealthBarReveal(enemyHealthMaskAnim, enemyHealthNumbersAnim) }
+            launch {
+                timerSlideAnim.animateTo(1f, tween(TIMER_SLIDE_MS, easing = FastOutSlowInEasing))
+            }
+        }
+        delay(GROUP_GAP_MS)
 
-        enemyHealthMaskAnim.animateTo(1f, tween(HEALTH_MASK_MS, easing = FastOutSlowInEasing))
-        delay(SUB_STAGE_GAP_MS)
-        enemyHealthNumbersAnim.animateTo(1f, tween(HEALTH_NUMBERS_FADE_MS, easing = LinearEasing))
-        delay(STAGE_GAP_MS)
-
-        timerSlideAnim.animateTo(1f, tween(TIMER_SLIDE_MS, easing = FastOutSlowInEasing))
-        delay(STAGE_GAP_MS)
-
+        // Group 3 — turn indicator, skill stagger, and player health bar
+        // (mask → numbers) all play together.
         val skillTotalMs = skillStaggerTotalMs(skillSlotCount)
-        skillClockAnim.animateTo(
-            targetValue = skillTotalMs.toFloat(),
-            animationSpec = tween(skillTotalMs, easing = LinearEasing),
-        )
-        delay(STAGE_GAP_MS)
+        coroutineScope {
+            launch {
+                turnIndicatorAnim.animateTo(
+                    targetValue = 1f,
+                    animationSpec = tween(TURN_INDICATOR_FADE_MS, easing = LinearEasing),
+                )
+            }
+            launch {
+                skillClockAnim.animateTo(
+                    targetValue = skillTotalMs.toFloat(),
+                    animationSpec = tween(skillTotalMs, easing = LinearEasing),
+                )
+            }
+            launch { animateHealthBarReveal(playerHealthMaskAnim, playerHealthNumbersAnim) }
+        }
 
-        playerHealthMaskAnim.animateTo(1f, tween(HEALTH_MASK_MS, easing = FastOutSlowInEasing))
-        delay(SUB_STAGE_GAP_MS)
-        playerHealthNumbersAnim.animateTo(1f, tween(HEALTH_NUMBERS_FADE_MS, easing = LinearEasing))
-        delay(STAGE_GAP_MS)
-
-        turnIndicatorAnim.animateTo(1f, tween(TURN_INDICATOR_FADE_MS, easing = LinearEasing))
         isCompleted = true
+    }
+
+    /** Mask the bar from the centre outward, hold briefly, then fade in the numbers. */
+    private suspend fun animateHealthBarReveal(
+        maskAnim: Animatable<Float, AnimationVector1D>,
+        numbersAnim: Animatable<Float, AnimationVector1D>,
+    ) {
+        maskAnim.animateTo(1f, tween(HEALTH_MASK_MS, easing = FastOutSlowInEasing))
+        delay(SUB_STAGE_GAP_MS)
+        numbersAnim.animateTo(1f, tween(HEALTH_NUMBERS_FADE_MS, easing = LinearEasing))
     }
 
     /** Snaps every stage to its final value, e.g. when previewing without animation. */

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatPlayerControls.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatPlayerControls.kt
@@ -39,6 +39,7 @@ internal fun PlayerControls(
     onStatusClick: (CombatActiveStatusDomain) -> Unit,
     onDismissPopup: () -> Unit,
     skillSlotIntroScale: (slotIndex: Int) -> Float = { 1f },
+    skillSlotIntroAlpha: (slotIndex: Int) -> Float = { 1f },
     playerBarRevealProgress: Float = 1f,
     playerBarNumbersAlpha: Float = 1f,
 ) {
@@ -54,6 +55,7 @@ internal fun PlayerControls(
                 onApplyGoalProgress = onApplyGoalProgress,
                 modifier = Modifier.alpha(dimAlpha),
                 slotIntroScale = skillSlotIntroScale,
+                slotIntroAlpha = skillSlotIntroAlpha,
             )
 
             Kiwi_Spacer(Spacing.small)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatPlayerControls.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatPlayerControls.kt
@@ -28,6 +28,7 @@ private val STATUS_POPUP_BOTTOM_OFFSET = 44.dp
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
+@Suppress("LongParameterList")
 internal fun PlayerControls(
     deckSkills: List<SkillDomain>,
     userActor: CombatActorDomain,
@@ -37,6 +38,9 @@ internal fun PlayerControls(
     onApplyGoalProgress: (skillId: Long, goalId: Long, newProgress: Int) -> Unit,
     onStatusClick: (CombatActiveStatusDomain) -> Unit,
     onDismissPopup: () -> Unit,
+    skillSlotIntroScale: (slotIndex: Int) -> Float = { 1f },
+    playerBarRevealProgress: Float = 1f,
+    playerBarNumbersAlpha: Float = 1f,
 ) {
     val colors = LocalKiwiColors.current
     val dimAlpha = if (isOverlayOpen) KIWI_DISABLED_ALPHA else 1f
@@ -49,6 +53,7 @@ internal fun PlayerControls(
                 onSkillClick = onSkillClick,
                 onApplyGoalProgress = onApplyGoalProgress,
                 modifier = Modifier.alpha(dimAlpha),
+                slotIntroScale = skillSlotIntroScale,
             )
 
             Kiwi_Spacer(Spacing.small)
@@ -63,6 +68,8 @@ internal fun PlayerControls(
                         .align(Alignment.CenterHorizontally)
                         .fillMaxWidth(PLAYER_HEALTH_BAR_WIDTH_FRACTION)
                         .alpha(dimAlpha),
+                barRevealProgress = playerBarRevealProgress,
+                numbersAlpha = playerBarNumbersAlpha,
             )
 
             Kiwi_Spacer(Spacing.small)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTimer.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTimer.kt
@@ -10,6 +10,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,10 +31,20 @@ private const val SECONDS_PER_HOUR = 3600L
 private const val EMPTY_TIMER = "--:--:--"
 private val TIMER_RADIUS = 20.dp
 
+// How far the timer starts shifted up at [introProgress] = 0, in dp. Sized so
+// the whole timer panel sits hidden behind the health bar above it during the
+// combat intro; the bar above must be rendered on top (zIndex) for the
+// "from behind" effect to read correctly.
+private val TIMER_INTRO_HIDE_OFFSET = 60.dp
+
 @Composable
 fun CombatTimer(
     endsAt: Long?,
     modifier: Modifier = Modifier,
+    // 0f = panel parked above its layout slot (so a higher-zIndex element
+    // covers it), 1f = settled in place. Drives the "slides out from behind
+    // the health bar" beat of the combat intro.
+    introProgress: Float = 1f,
 ) {
     val colors = LocalKiwiColors.current
 
@@ -51,9 +64,14 @@ fun CombatTimer(
             formatRemaining((endsAt - now).coerceAtLeast(0L))
         }
 
+    val hideOffsetPx = with(LocalDensity.current) { TIMER_INTRO_HIDE_OFFSET.toPx() }
+    val translationY = -hideOffsetPx * (1f - introProgress.coerceIn(0f, 1f))
+
     Box(
         modifier =
             modifier
+                .graphicsLayer { this.translationY = translationY }
+                .alpha(introProgress.coerceIn(0f, 1f))
                 .combatPanel(bgColor = colors.color2, borderColor = colors.color5C, radius = TIMER_RADIUS)
                 .padding(
                     horizontal = getResponsiveSizeWidth(Spacing.medium),

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
@@ -50,12 +50,14 @@ private val TURN_GLOW_DAMAGE = Color(0xB3D63A2F)
 private val TURN_GLOW_STAT_MOD = Color(0xB330B0FF)
 
 @Composable
+@Suppress("LongParameterList")
 fun CombatTurnIndicator(
     message: AnnotatedString,
     isLogOpen: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     glowColor: Color? = null,
+    introAlpha: Float = 1f,
 ) {
     val colors = LocalKiwiColors.current
     val rotation by animateFloatAsState(
@@ -72,6 +74,7 @@ fun CombatTurnIndicator(
         modifier =
             modifier
                 .fillMaxWidth()
+                .alpha(introAlpha)
                 .combatPanel(
                     bgColor = colors.color3A,
                     borderColor = colors.color5C,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -43,6 +43,7 @@ import com.bellako.kiwi.features.combat.components.CombatHeader
 import com.bellako.kiwi.features.combat.components.CombatTurnIndicator
 import com.bellako.kiwi.features.combat.components.DeathSequenceOverlay
 import com.bellako.kiwi.features.combat.components.LogDimOverlay
+import com.bellako.kiwi.features.combat.components.CombatIntroController
 import com.bellako.kiwi.features.combat.components.PlayerControls
 import com.bellako.kiwi.features.combat.components.PlayerDamageOverlays
 import com.bellako.kiwi.features.combat.components.buildCombatLogEntries
@@ -179,58 +180,23 @@ fun CombatScreen(
                     timerIntroProgress = intro.timerSlideProgress,
                 )
 
-                Box {
-                    Column(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .background(
-                                    Brush.verticalGradient(
-                                        BOTTOM_PANEL_GRADIENT_START to Color.Transparent,
-                                        BOTTOM_PANEL_GRADIENT_MID to colors.color2,
-                                        BOTTOM_PANEL_GRADIENT_END to colors.color2,
-                                    ),
-                                ).padding(
-                                    horizontal = getResponsiveSizeWidth(Spacing.medium),
-                                    vertical = getResponsiveSizeHeight(Spacing.small),
-                                ),
-                    ) {
-                        CombatTurnIndicator(
-                            message = turnMessage,
-                            isLogOpen = isLogOpen,
-                            onClick = { isLogOpen = !isLogOpen },
-                            glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
-                            introAlpha = intro.turnIndicatorAlpha,
-                        )
-
-                        Kiwi_Spacer(Spacing.medium)
-
-                        PlayerControls(
-                            deckSkills = deckSkills,
-                            userActor = combat.user,
-                            isOverlayOpen = isOverlayOpen,
-                            selectedStatus = selectedStatus,
-                            onSkillClick = onSkillClick,
-                            onApplyGoalProgress = onApplyGoalProgress,
-                            onStatusClick = { status ->
-                                selectedStatus = if (selectedStatus?.stateId == status.stateId) null else status
-                            },
-                            onDismissPopup = { selectedStatus = null },
-                            skillSlotIntroScale = { slotIndex -> intro.skillSlotScale(slotIndex) },
-                            playerBarRevealProgress = intro.playerHealthMaskProgress,
-                            playerBarNumbersAlpha = intro.playerHealthNumbersAlpha,
-                        )
-
-                        Kiwi_Spacer(Spacing.large)
-                    }
-
-                    if (isLogOpen) {
-                        LogDimOverlay(
-                            modifier = Modifier.matchParentSize(),
-                            onDismiss = { isLogOpen = false },
-                        )
-                    }
-                }
+                CombatBottomPanel(
+                    combat = combat,
+                    deckSkills = deckSkills,
+                    turnMessage = turnMessage,
+                    isLogOpen = isLogOpen,
+                    isOverlayOpen = isOverlayOpen,
+                    selectedStatus = selectedStatus,
+                    intro = intro,
+                    onToggleLog = { isLogOpen = !isLogOpen },
+                    onCloseLog = { isLogOpen = false },
+                    onSkillClick = onSkillClick,
+                    onApplyGoalProgress = onApplyGoalProgress,
+                    onStatusClick = { status ->
+                        selectedStatus = if (selectedStatus?.stateId == status.stateId) null else status
+                    },
+                    onDismissPopup = { selectedStatus = null },
+                )
             }
         }
 
@@ -264,6 +230,78 @@ fun CombatScreen(
             },
             onCancel = { showAbandonConfirm = false },
         )
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+@Composable
+@Suppress("LongParameterList")
+private fun CombatBottomPanel(
+    combat: CombatDomain,
+    deckSkills: List<SkillDomain>,
+    turnMessage: AnnotatedString,
+    isLogOpen: Boolean,
+    isOverlayOpen: Boolean,
+    selectedStatus: CombatActiveStatusDomain?,
+    intro: CombatIntroController,
+    onToggleLog: () -> Unit,
+    onCloseLog: () -> Unit,
+    onSkillClick: (skillId: Long, skillName: String) -> Unit,
+    onApplyGoalProgress: (skillId: Long, goalId: Long, newProgress: Int) -> Unit,
+    onStatusClick: (CombatActiveStatusDomain) -> Unit,
+    onDismissPopup: () -> Unit,
+) {
+    val colors = LocalKiwiColors.current
+    Box {
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.verticalGradient(
+                            BOTTOM_PANEL_GRADIENT_START to Color.Transparent,
+                            BOTTOM_PANEL_GRADIENT_MID to colors.color2,
+                            BOTTOM_PANEL_GRADIENT_END to colors.color2,
+                        ),
+                    ).padding(
+                        horizontal = getResponsiveSizeWidth(Spacing.medium),
+                        vertical = getResponsiveSizeHeight(Spacing.small),
+                    ),
+        ) {
+            CombatTurnIndicator(
+                message = turnMessage,
+                isLogOpen = isLogOpen,
+                onClick = onToggleLog,
+                glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
+                introAlpha = intro.turnIndicatorAlpha,
+            )
+
+            Kiwi_Spacer(Spacing.medium)
+
+            PlayerControls(
+                deckSkills = deckSkills,
+                userActor = combat.user,
+                isOverlayOpen = isOverlayOpen,
+                selectedStatus = selectedStatus,
+                onSkillClick = onSkillClick,
+                onApplyGoalProgress = onApplyGoalProgress,
+                onStatusClick = onStatusClick,
+                onDismissPopup = onDismissPopup,
+                skillSlotIntroScale = { slotIndex -> intro.skillSlotScale(slotIndex) },
+                skillSlotIntroAlpha = { slotIndex -> intro.skillSlotAlpha(slotIndex) },
+                playerBarRevealProgress = intro.playerHealthMaskProgress,
+                playerBarNumbersAlpha = intro.playerHealthNumbersAlpha,
+            )
+
+            Kiwi_Spacer(Spacing.large)
+        }
+
+        if (isLogOpen) {
+            LogDimOverlay(
+                modifier = Modifier.matchParentSize(),
+                onDismiss = onCloseLog,
+            )
+        }
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -12,9 +12,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.BiasAlignment
@@ -45,6 +47,7 @@ import com.bellako.kiwi.features.combat.components.PlayerControls
 import com.bellako.kiwi.features.combat.components.PlayerDamageOverlays
 import com.bellako.kiwi.features.combat.components.buildCombatLogEntries
 import com.bellako.kiwi.features.combat.components.combatTurnGlowColor
+import com.bellako.kiwi.features.combat.components.rememberCombatIntroController
 import com.bellako.kiwi.features.combat.components.rememberDeathSequenceVfx
 import com.bellako.kiwi.features.combat.components.rememberPlayerDamageVfx
 import com.bellako.kiwi.features.combat.components.userTurnMessage
@@ -56,7 +59,10 @@ import com.bellako.kiwi.features.combat.data.CombatActor
 import com.bellako.kiwi.features.combat.data.CombatDomain
 import com.bellako.kiwi.features.combat.data.CombatGeneralStatus
 import com.bellako.kiwi.features.combat.tests.CombatTestFactory
+import com.bellako.kiwi.features.nodes.screens.LocalNodeEntryTransition
 import com.bellako.kiwi.features.skills.data.SkillDomain
+import com.bellako.kiwi.features.skills.model.MAX_DECK_SLOTS
+import kotlinx.coroutines.launch
 import com.bellako.kiwi.features.skills.tests.SkillsTestFactory
 import com.bellako.kiwi.ui.KiwiColors
 import com.bellako.kiwi.ui.Kiwi_Theme
@@ -90,7 +96,13 @@ fun CombatScreen(
     var isLogOpen by rememberSaveable(combat.id) { mutableStateOf(false) }
     var selectedStatus by remember(combat.id) { mutableStateOf<CombatActiveStatusDomain?>(null) }
     var showAbandonConfirm by rememberSaveable(combat.id) { mutableStateOf(false) }
-    val isOverlayOpen = isLogOpen || selectedStatus != null || isTurnPlaying || activeBark != null
+
+    val intro = rememberCombatIntroController()
+    // Withhold any bark until the intro is fully over — barks pulling focus
+    // while the HUD is still introing makes the sequence read as cluttered.
+    val displayedBark = if (intro.isCompleted) activeBark else null
+    val isOverlayOpen =
+        isLogOpen || selectedStatus != null || isTurnPlaying || displayedBark != null
 
     val enemyName = combat.enemyName.ifBlank { DEFAULT_ENEMY_NAME }
     val turnMessage = currentTurnMessage(combat, enemyName)
@@ -106,6 +118,20 @@ fun CombatScreen(
 
     val playerVfx = rememberPlayerDamageVfx(combat.user.stats.currentHp, combat.id)
     val deathVignetteAlpha = rememberDeathSequenceVfx(combat.user.stats.currentHp == 0, combat.id)
+    val nodeEntry = LocalNodeEntryTransition.current
+    val nodeEntryScope = rememberCoroutineScope()
+    LaunchedEffect(Unit) {
+        intro.play(
+            skillSlotCount = MAX_DECK_SLOTS,
+            onBackgroundShown = {
+                // Background is now opaque, so the node-entry white veil can lift
+                // without the player glimpsing the map underneath.
+                nodeEntry?.let { controller ->
+                    nodeEntryScope.launch { controller.fadeOut() }
+                }
+            },
+        )
+    }
 
     Box(
         modifier =
@@ -119,13 +145,14 @@ fun CombatScreen(
                     .fillMaxSize()
                     .graphicsLayer { translationX = playerVfx.shakeOffsetX.value },
         ) {
-            CombatBackground(combat.background)
+            CombatBackground(combat.background, alpha = intro.backgroundAlpha)
 
             CombatEnemySprite(
                 enemySprite = combat.enemySprite,
                 currentHp = combat.enemy.stats.currentHp,
                 isEnemyDefeated = combat.combatStatus == CombatGeneralStatus.USER_WON,
                 context = context,
+                introAlpha = intro.enemyAlpha,
             )
 
             Column(modifier = Modifier.fillMaxSize().padding(top = Spacing.large)) {
@@ -147,6 +174,9 @@ fun CombatScreen(
                     isLogOpen = isLogOpen,
                     onDismissLog = { isLogOpen = false },
                     logEntries = logEntries,
+                    enemyBarRevealProgress = intro.enemyHealthMaskProgress,
+                    enemyBarNumbersAlpha = intro.enemyHealthNumbersAlpha,
+                    timerIntroProgress = intro.timerSlideProgress,
                 )
 
                 Box {
@@ -170,6 +200,7 @@ fun CombatScreen(
                             isLogOpen = isLogOpen,
                             onClick = { isLogOpen = !isLogOpen },
                             glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
+                            introAlpha = intro.turnIndicatorAlpha,
                         )
 
                         Kiwi_Spacer(Spacing.medium)
@@ -185,6 +216,9 @@ fun CombatScreen(
                                 selectedStatus = if (selectedStatus?.stateId == status.stateId) null else status
                             },
                             onDismissPopup = { selectedStatus = null },
+                            skillSlotIntroScale = { slotIndex -> intro.skillSlotScale(slotIndex) },
+                            playerBarRevealProgress = intro.playerHealthMaskProgress,
+                            playerBarNumbersAlpha = intro.playerHealthNumbersAlpha,
                         )
 
                         Kiwi_Spacer(Spacing.large)
@@ -201,7 +235,7 @@ fun CombatScreen(
         }
 
         Crossfade(
-            targetState = activeBark,
+            targetState = displayedBark,
             animationSpec = tween(BARK_FADE_MS),
             label = "combat_bark",
         ) { bark ->

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -125,7 +125,7 @@ fun CombatScreen(
         intro.play(
             skillSlotCount = MAX_DECK_SLOTS,
             onBackgroundShown = {
-                // Background is now opaque, so the node-entry white veil can lift
+                // Background is now opaque, so the node-entry veil can lift
                 // without the player glimpsing the map underneath.
                 nodeEntry?.let { controller ->
                     nodeEntryScope.launch { controller.fadeOut() }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -3,7 +3,11 @@ package com.bellako.kiwi.features.conversations.screens
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.EaseOutBack
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
@@ -13,6 +17,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,11 +27,15 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
@@ -34,6 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
 import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
@@ -54,6 +64,15 @@ import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 
+private const val BG_LERP_MS = 900
+private const val CHARACTER_LERP_MS = 900
+private const val DIALOGUE_FADE_MS = 600
+private const val OPTION_POP_MS = 450
+private const val OPTION_STAGGER_MS = 140
+private const val STAGE_GAP_MS = 250L
+
+private const val PROTAGONIST_SPRITE_KEY = "liria"
+
 @Composable
 @Suppress("MagicNumber")
 fun ConversationScreen(
@@ -73,114 +92,174 @@ fun ConversationScreen(
         label = "arrow_offset",
     )
     val context = LocalContext.current
+    val backgroundRes = AssetResolver.drawable(context, conversation.background)
 
-    // Background image
-    Column(
-        verticalArrangement = Arrangement.Bottom,
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .clickable {},
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .height(getResponsiveSizeHeight(400.dp))
-                    .fillMaxWidth()
-                    .offset(
-                        x = getResponsiveSizeWidth(-50.dp),
-                        y = getResponsiveSizeHeight(100.dp),
-                    ),
-        ) {
-            // Sprite
+    // Liria enters from the bottom; everyone else slides in from the left.
+    // Sprite identifiers vary in case and can embed "liria" anywhere in the
+    // string (e.g. "character_liria_neutral"), so match case-insensitively
+    // anywhere in the name.
+    val isProtagonist = conversation.sprite.contains(PROTAGONIST_SPRITE_KEY, ignoreCase = true)
+
+    val bgProgress = remember { Animatable(0f) }
+    val characterProgress = remember { Animatable(0f) }
+    val dialogueAlpha = remember { Animatable(0f) }
+    val optionsClockMs = remember { Animatable(0f) }
+
+    val optionsTotalMs =
+        OPTION_POP_MS + (conversation.options.size - 1).coerceAtLeast(0) * OPTION_STAGGER_MS
+
+    LaunchedEffect(Unit) {
+        bgProgress.animateTo(1f, tween(BG_LERP_MS, easing = FastOutSlowInEasing))
+        delay(STAGE_GAP_MS)
+        characterProgress.animateTo(1f, tween(CHARACTER_LERP_MS, easing = FastOutSlowInEasing))
+        delay(STAGE_GAP_MS)
+        dialogueAlpha.animateTo(1f, tween(DIALOGUE_FADE_MS, easing = LinearEasing))
+        delay(STAGE_GAP_MS)
+        optionsClockMs.animateTo(
+            targetValue = optionsTotalMs.toFloat(),
+            animationSpec = tween(optionsTotalMs, easing = LinearEasing),
+        )
+    }
+
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val screenWidth = maxWidth
+        val screenHeight = maxHeight
+
+        if (backgroundRes != null) {
             Kiwi_Image(
-                painterResourceId =
-                    AssetResolver.drawableOr(context, conversation.sprite, R.drawable.character_liria_base),
-                alt = "Character Pose",
-            )
-        }
-        // Dialogue
-        Box(
-            modifier =
-                Modifier.fillMaxWidth().background(
-                    Brush.verticalGradient(
-                        -0.2f to Color.Transparent,
-                        0.5f to kiwiColor.color2,
-                        1f to kiwiColor.color2,
-                    ),
-                ),
-        ) {
-            Box(
-                contentAlignment = Alignment.Center,
-                modifier = Modifier.padding(horizontal = Spacing.medium),
-            ) {
-                Kiwi_Image(
-                    painterResourceId = getAsset(conversation, R.drawable.dialogue_light_small, LocalContext.current),
-                    alt = "Conversation modal",
-                    contentScale = ContentScale.FillWidth,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                Kiwi_P2(
-                    KiwiTextArguments(
-                        conversation.dialog,
-                        textAlign = TextAlign.Center,
-                        color = if (conversation.dark) kiwiColor.color6 else kiwiColor.color3,
-                        modifier =
-                            Modifier.padding(Spacing.medium, Spacing.medium),
-                    ),
-                )
-                Box(
-                    modifier =
-                        Modifier
-                            .matchParentSize()
-                            .offset(x = getResponsiveSizeWidth(25.dp)),
-                ) {
-                    CharacterName("Liria", conversation.dark, false)
-                }
-            }
-        }
-        // Options
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(kiwiColor.color2),
-        ) {
-            val optionHeight = getResponsiveSizeHeight(50.dp)
-            val maxVisible = 3
-            Kiwi_Spacer(Spacing.medium)
-            LazyColumn(
+                painterResourceId = backgroundRes,
+                alt = "Conversation background",
+                contentScale = ContentScale.Crop,
                 modifier =
                     Modifier
-                        .padding(horizontal = Spacing.medium)
-                        .heightIn(max = optionHeight * maxVisible + Spacing.small * 2),
+                        .fillMaxSize()
+                        .offset(y = screenHeight * (1f - bgProgress.value)),
+            )
+        }
+
+        Column(
+            verticalArrangement = Arrangement.Bottom,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .clickable {},
+        ) {
+            val charExtraX =
+                if (isProtagonist) 0.dp else -screenWidth * (1f - characterProgress.value)
+            val charExtraY =
+                if (isProtagonist) screenHeight * (1f - characterProgress.value) else 0.dp
+
+            Box(
+                modifier =
+                    Modifier
+                        .height(getResponsiveSizeHeight(400.dp))
+                        .fillMaxWidth()
+                        .offset(
+                            x = getResponsiveSizeWidth(-50.dp) + charExtraX,
+                            y = getResponsiveSizeHeight(100.dp) + charExtraY,
+                        ),
             ) {
-                items(conversation.options) { option ->
-                    ConversationOption(option, onClick = {
-                        AudioManager.playSFX(context, R.raw.snd_fx_03_page)
-                        viewModel?.next(option)
-                    })
-                    Kiwi_Spacer(Spacing.small)
+                // Sprite
+                Kiwi_Image(
+                    painterResourceId =
+                        AssetResolver.drawableOr(context, conversation.sprite, R.drawable.character_liria_base),
+                    alt = "Character Pose",
+                )
+            }
+            // Dialogue
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .alpha(dialogueAlpha.value)
+                        .background(
+                            Brush.verticalGradient(
+                                -0.2f to Color.Transparent,
+                                0.5f to kiwiColor.color2,
+                                1f to kiwiColor.color2,
+                            ),
+                        ),
+            ) {
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.padding(horizontal = Spacing.medium),
+                ) {
+                    Kiwi_Image(
+                        painterResourceId = getAsset(conversation, R.drawable.dialogue_light_small, LocalContext.current),
+                        alt = "Conversation modal",
+                        contentScale = ContentScale.FillWidth,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    Kiwi_P2(
+                        KiwiTextArguments(
+                            conversation.dialog,
+                            textAlign = TextAlign.Center,
+                            color = if (conversation.dark) kiwiColor.color6 else kiwiColor.color3,
+                            modifier =
+                                Modifier.padding(Spacing.medium, Spacing.medium),
+                        ),
+                    )
+                    Box(
+                        modifier =
+                            Modifier
+                                .matchParentSize()
+                                .offset(x = getResponsiveSizeWidth(25.dp)),
+                    ) {
+                        CharacterName("Liria", conversation.dark, false)
+                    }
                 }
             }
-            if (conversation.options.size == 0) {
+            // Options
+            Column(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .alpha(dialogueAlpha.value)
+                        .background(kiwiColor.color2),
+            ) {
+                val optionHeight = getResponsiveSizeHeight(50.dp)
+                val maxVisible = 3
                 Kiwi_Spacer(Spacing.medium)
-                Kiwi_Image(
-                    R.drawable.ic_dialogue_arrow,
-                    "Arrow",
+                LazyColumn(
                     modifier =
                         Modifier
-                            .fillMaxWidth()
-                            .size(getResponsiveSizeWidth(8.dp), getResponsiveSizeHeight(8.dp))
-                            .offset(y = getResponsiveSizeHeight(offsetY.dp))
-                            .clickable {
+                            .padding(horizontal = Spacing.medium)
+                            .heightIn(max = optionHeight * maxVisible + Spacing.small * 2),
+                ) {
+                    itemsIndexed(conversation.options) { index, option ->
+                        val itemStart = index * OPTION_STAGGER_MS
+                        val rawP =
+                            ((optionsClockMs.value - itemStart) / OPTION_POP_MS).coerceIn(0f, 1f)
+                        val popScale =
+                            if (rawP <= 0f) 0f else EaseOutBack.transform(rawP).coerceAtLeast(0f)
+                        Box(modifier = Modifier.scale(popScale)) {
+                            ConversationOption(option, onClick = {
                                 AudioManager.playSFX(context, R.raw.snd_fx_03_page)
-                                viewModel?.next()
-                            },
-                )
-                Kiwi_Spacer(Spacing.large)
-            } else {
-                Kiwi_Spacer(Spacing.xLarge)
+                                viewModel?.next(option)
+                            })
+                        }
+                        Kiwi_Spacer(Spacing.small)
+                    }
+                }
+                if (conversation.options.size == 0) {
+                    Kiwi_Spacer(Spacing.medium)
+                    Kiwi_Image(
+                        R.drawable.ic_dialogue_arrow,
+                        "Arrow",
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .size(getResponsiveSizeWidth(8.dp), getResponsiveSizeHeight(8.dp))
+                                .offset(y = getResponsiveSizeHeight(offsetY.dp))
+                                .clickable {
+                                    AudioManager.playSFX(context, R.raw.snd_fx_03_page)
+                                    viewModel?.next()
+                                },
+                    )
+                    Kiwi_Spacer(Spacing.large)
+                } else {
+                    Kiwi_Spacer(Spacing.xLarge)
+                }
             }
         }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
@@ -58,13 +59,14 @@ import com.bellako.kiwi.features.conversations.data.ConversationOptionDomain
 import com.bellako.kiwi.features.conversations.data.ConversationType
 import com.bellako.kiwi.features.conversations.data.NextEventType
 import com.bellako.kiwi.features.conversations.model.ConversationViewModel
+import com.bellako.kiwi.features.nodes.screens.LocalNodeEntryTransition
 import com.bellako.kiwi.ui.Kiwi_Theme
 import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 
-private const val BG_LERP_MS = 900
+private const val BG_FADE_MS = 700
 private const val CHARACTER_LERP_MS = 900
 private const val DIALOGUE_FADE_MS = 600
 private const val OPTION_POP_MS = 450
@@ -100,7 +102,7 @@ fun ConversationScreen(
     // anywhere in the name.
     val isProtagonist = conversation.sprite.contains(PROTAGONIST_SPRITE_KEY, ignoreCase = true)
 
-    val bgProgress = remember { Animatable(0f) }
+    val bgAlpha = remember { Animatable(0f) }
     val characterProgress = remember { Animatable(0f) }
     val dialogueAlpha = remember { Animatable(0f) }
     val optionsClockMs = remember { Animatable(0f) }
@@ -108,8 +110,14 @@ fun ConversationScreen(
     val optionsTotalMs =
         OPTION_POP_MS + (conversation.options.size - 1).coerceAtLeast(0) * OPTION_STAGGER_MS
 
+    val nodeEntry = LocalNodeEntryTransition.current
+
     LaunchedEffect(Unit) {
-        bgProgress.animateTo(1f, tween(BG_LERP_MS, easing = FastOutSlowInEasing))
+        bgAlpha.animateTo(1f, tween(BG_FADE_MS, easing = LinearEasing))
+        // BG is fully opaque now, so it's safe to lift the node-entry veil —
+        // the player won't see the map through a half-faded BG. Launched in
+        // parallel so the character lerp doesn't wait for the veil to lift.
+        launch { nodeEntry?.fadeOut() }
         delay(STAGE_GAP_MS)
         characterProgress.animateTo(1f, tween(CHARACTER_LERP_MS, easing = FastOutSlowInEasing))
         delay(STAGE_GAP_MS)
@@ -133,7 +141,7 @@ fun ConversationScreen(
                 modifier =
                     Modifier
                         .fillMaxSize()
-                        .offset(y = screenHeight * (1f - bgProgress.value)),
+                        .alpha(bgAlpha.value),
             )
         }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -217,58 +217,78 @@ fun ConversationScreen(
                     }
                 }
             }
-            // Options
-            Column(
+            ConversationOptionsPanel(
+                options = conversation.options,
+                alpha = dialogueAlpha.value,
+                optionsClockMs = optionsClockMs.value,
+                arrowBounceOffsetY = offsetY,
+                onOptionClick = { option ->
+                    AudioManager.playSFX(context, R.raw.snd_fx_03_page)
+                    viewModel?.next(option)
+                },
+                onAdvance = {
+                    AudioManager.playSFX(context, R.raw.snd_fx_03_page)
+                    viewModel?.next()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+@Suppress("MagicNumber")
+private fun ConversationOptionsPanel(
+    options: List<ConversationOptionDomain>,
+    alpha: Float,
+    optionsClockMs: Float,
+    arrowBounceOffsetY: Float,
+    onOptionClick: (ConversationOptionDomain) -> Unit,
+    onAdvance: () -> Unit,
+) {
+    val kiwiColor = LocalKiwiColors.current
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .alpha(alpha)
+                .background(kiwiColor.color2),
+    ) {
+        val optionHeight = getResponsiveSizeHeight(50.dp)
+        val maxVisible = 3
+        Kiwi_Spacer(Spacing.medium)
+        LazyColumn(
+            modifier =
+                Modifier
+                    .padding(horizontal = Spacing.medium)
+                    .heightIn(max = optionHeight * maxVisible + Spacing.small * 2),
+        ) {
+            itemsIndexed(options) { index, option ->
+                val itemStart = index * OPTION_STAGGER_MS
+                val rawP =
+                    ((optionsClockMs - itemStart) / OPTION_POP_MS).coerceIn(0f, 1f)
+                val popScale =
+                    if (rawP <= 0f) 0f else EaseOutBack.transform(rawP).coerceAtLeast(0f)
+                Box(modifier = Modifier.scale(popScale)) {
+                    ConversationOption(option, onClick = { onOptionClick(option) })
+                }
+                Kiwi_Spacer(Spacing.small)
+            }
+        }
+        if (options.isEmpty()) {
+            Kiwi_Spacer(Spacing.medium)
+            Kiwi_Image(
+                R.drawable.ic_dialogue_arrow,
+                "Arrow",
                 modifier =
                     Modifier
                         .fillMaxWidth()
-                        .alpha(dialogueAlpha.value)
-                        .background(kiwiColor.color2),
-            ) {
-                val optionHeight = getResponsiveSizeHeight(50.dp)
-                val maxVisible = 3
-                Kiwi_Spacer(Spacing.medium)
-                LazyColumn(
-                    modifier =
-                        Modifier
-                            .padding(horizontal = Spacing.medium)
-                            .heightIn(max = optionHeight * maxVisible + Spacing.small * 2),
-                ) {
-                    itemsIndexed(conversation.options) { index, option ->
-                        val itemStart = index * OPTION_STAGGER_MS
-                        val rawP =
-                            ((optionsClockMs.value - itemStart) / OPTION_POP_MS).coerceIn(0f, 1f)
-                        val popScale =
-                            if (rawP <= 0f) 0f else EaseOutBack.transform(rawP).coerceAtLeast(0f)
-                        Box(modifier = Modifier.scale(popScale)) {
-                            ConversationOption(option, onClick = {
-                                AudioManager.playSFX(context, R.raw.snd_fx_03_page)
-                                viewModel?.next(option)
-                            })
-                        }
-                        Kiwi_Spacer(Spacing.small)
-                    }
-                }
-                if (conversation.options.size == 0) {
-                    Kiwi_Spacer(Spacing.medium)
-                    Kiwi_Image(
-                        R.drawable.ic_dialogue_arrow,
-                        "Arrow",
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .size(getResponsiveSizeWidth(8.dp), getResponsiveSizeHeight(8.dp))
-                                .offset(y = getResponsiveSizeHeight(offsetY.dp))
-                                .clickable {
-                                    AudioManager.playSFX(context, R.raw.snd_fx_03_page)
-                                    viewModel?.next()
-                                },
-                    )
-                    Kiwi_Spacer(Spacing.large)
-                } else {
-                    Kiwi_Spacer(Spacing.xLarge)
-                }
-            }
+                        .size(getResponsiveSizeWidth(8.dp), getResponsiveSizeHeight(8.dp))
+                        .offset(y = getResponsiveSizeHeight(arrowBounceOffsetY.dp))
+                        .clickable(onClick = onAdvance),
+            )
+            Kiwi_Spacer(Spacing.large)
+        } else {
+            Kiwi_Spacer(Spacing.xLarge)
         }
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/model/MapViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/model/MapViewModel.kt
@@ -41,6 +41,17 @@ class MapViewModel
         private val _state = kotlinx.coroutines.flow.MutableStateFlow(MapState(scale = initialScale))
         override val state: kotlinx.coroutines.flow.StateFlow<MapState> = _state.asStateFlow()
 
+        // Whether the node-reveal sequence has already run for this map session.
+        // Scoped to the HOME back-stack entry's ViewModel: it survives leaving the
+        // map and coming back (e.g. via Settings) but is recreated on a fresh
+        // login, so the reveal plays once per login and never again afterwards.
+        private val _revealConsumed = kotlinx.coroutines.flow.MutableStateFlow(false)
+        val revealConsumed: kotlinx.coroutines.flow.StateFlow<Boolean> = _revealConsumed.asStateFlow()
+
+        fun markRevealConsumed() {
+            _revealConsumed.value = true
+        }
+
         private var flingJob: Job? = null
         private var lastPointerPosition = Offset.Zero
         private var lastPointerTime = 0L

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
@@ -416,34 +416,34 @@ fun Background(mapViewModel: MapViewModel) {
     )
 }
 
-// Fallback hold before auto-dismissing the white veil. The follow-up screen
-// (e.g. ConversationScreen) is expected to call fadeOut() itself once its own
-// intro is settled, so the player never glimpses the map behind a half-faded
+// Fallback hold before auto-dismissing the veil. The follow-up screen (e.g.
+// ConversationScreen) is expected to call fadeOut() itself once its own intro
+// is settled, so the player never glimpses the map behind a half-faded
 // reveal. This is just a safety net for follow-ups that don't self-dismiss.
-private const val FALLBACK_WHITEOUT_HOLD_MS = 1_500L
+private const val FALLBACK_VEIL_HOLD_MS = 1_500L
 
 /**
- * Plays the white-veil transition (fade in + brief hold), runs
- * [onWhiteoutReached] (typically emitting the event that mounts the next
- * sequence), then schedules a fallback fade-out. The follow-up screen can
- * dismiss the veil earlier by calling [NodeEntryTransitionController.fadeOut]
- * itself — [NodeEntryTransitionController.fadeOut] is idempotent, so the
- * fallback won't fight an earlier dismiss. If no controller is provided
- * (preview/tests) the callback runs immediately.
+ * Plays the veil transition (fade in + brief hold), runs [onVeilReached]
+ * (typically emitting the event that mounts the next sequence), then
+ * schedules a fallback fade-out. The follow-up screen can dismiss the veil
+ * earlier by calling [NodeEntryTransitionController.fadeOut] itself —
+ * [NodeEntryTransitionController.fadeOut] is idempotent, so the fallback
+ * won't fight an earlier dismiss. If no controller is provided (preview/tests)
+ * the callback runs immediately.
  */
 private fun runNodeEntry(
     scope: CoroutineScope,
     nodeEntry: NodeEntryTransitionController?,
-    onWhiteoutReached: suspend () -> Unit,
+    onVeilReached: suspend () -> Unit,
 ) {
     if (nodeEntry == null) {
-        scope.launch { onWhiteoutReached() }
+        scope.launch { onVeilReached() }
         return
     }
     scope.launch {
         nodeEntry.enter()
-        onWhiteoutReached()
-        delay(FALLBACK_WHITEOUT_HOLD_MS)
+        onVeilReached()
+        delay(FALLBACK_VEIL_HOLD_MS)
         nodeEntry.fadeOut()
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -50,8 +51,10 @@ import com.bellako.kiwi.features.map.data.MapsInfo
 import com.bellako.kiwi.features.map.model.MapViewModel
 import com.bellako.kiwi.features.nodes.data.NodeStatus
 import com.bellako.kiwi.features.nodes.model.INodesViewModel
+import com.bellako.kiwi.features.nodes.screens.LocalNodeEntryTransition
 import com.bellako.kiwi.features.nodes.screens.NodeAction
 import com.bellako.kiwi.features.nodes.screens.NodeConnections
+import com.bellako.kiwi.features.nodes.screens.NodeEntryTransitionController
 import com.bellako.kiwi.features.nodes.screens.NodeOnMap
 import com.bellako.kiwi.features.nodes.screens.distance
 import com.bellako.kiwi.features.nodes.screens.rememberNodeReveal
@@ -63,9 +66,8 @@ import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getScreenHeight
 import com.bellako.kiwi.ui.getScreenWidth
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -204,7 +206,6 @@ private fun loadNodes(
 }
 
 @Suppress("LongMethod")
-@OptIn(DelicateCoroutinesApi::class)
 @Composable
 private fun InteractiveMap(
     mapResourceId: Int,
@@ -229,6 +230,9 @@ private fun InteractiveMap(
             alreadyPlayed = revealConsumed,
             onRevealConsumed = mapViewModel::markRevealConsumed,
         )
+
+    val nodeEntry = LocalNodeEntryTransition.current
+    val nodeEntryScope = rememberCoroutineScope()
 
     Box(
         modifier =
@@ -362,8 +366,11 @@ private fun InteractiveMap(
                                     nodesViewModel.completeNode(id)
                                     AudioManager.playSFX(context, R.raw.snd_node_completed)
 
-                                    if (selectedNode.onExecutionEvent != "_") {
-                                        GlobalScope.launch(Dispatchers.Main) {
+                                    runNodeEntry(
+                                        scope = nodeEntryScope,
+                                        nodeEntry = nodeEntry,
+                                    ) {
+                                        if (selectedNode.onExecutionEvent != "_") {
                                             EventBus.emitEvent(
                                                 EventType.valueOf(selectedNode.onExecutionEvent),
                                                 EventPayload.EntityIdPayload(selectedNode.onExecutionEntityId),
@@ -372,8 +379,11 @@ private fun InteractiveMap(
                                     }
                                 },
                                 onRetryNode = { _ ->
-                                    if (selectedNode.onExecutionEvent != "_") {
-                                        GlobalScope.launch(Dispatchers.Main) {
+                                    runNodeEntry(
+                                        scope = nodeEntryScope,
+                                        nodeEntry = nodeEntry,
+                                    ) {
+                                        if (selectedNode.onExecutionEvent != "_") {
                                             EventBus.emitEvent(
                                                 EventType.valueOf(selectedNode.onExecutionEvent),
                                                 EventPayload.EntityIdPayload(selectedNode.onExecutionEntityId),
@@ -404,4 +414,36 @@ fun Background(mapViewModel: MapViewModel) {
                 .fillMaxSize()
                 .background(mapState.value.mapInfo.backgroundColor),
     )
+}
+
+// Fallback hold before auto-dismissing the white veil. The follow-up screen
+// (e.g. ConversationScreen) is expected to call fadeOut() itself once its own
+// intro is settled, so the player never glimpses the map behind a half-faded
+// reveal. This is just a safety net for follow-ups that don't self-dismiss.
+private const val FALLBACK_WHITEOUT_HOLD_MS = 1_500L
+
+/**
+ * Plays the white-veil transition (fade in + brief hold), runs
+ * [onWhiteoutReached] (typically emitting the event that mounts the next
+ * sequence), then schedules a fallback fade-out. The follow-up screen can
+ * dismiss the veil earlier by calling [NodeEntryTransitionController.fadeOut]
+ * itself — [NodeEntryTransitionController.fadeOut] is idempotent, so the
+ * fallback won't fight an earlier dismiss. If no controller is provided
+ * (preview/tests) the callback runs immediately.
+ */
+private fun runNodeEntry(
+    scope: CoroutineScope,
+    nodeEntry: NodeEntryTransitionController?,
+    onWhiteoutReached: suspend () -> Unit,
+) {
+    if (nodeEntry == null) {
+        scope.launch { onWhiteoutReached() }
+        return
+    }
+    scope.launch {
+        nodeEntry.enter()
+        onWhiteoutReached()
+        delay(FALLBACK_WHITEOUT_HOLD_MS)
+        nodeEntry.fadeOut()
+    }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
@@ -17,6 +17,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
@@ -50,6 +53,7 @@ import com.bellako.kiwi.features.nodes.screens.NodeAction
 import com.bellako.kiwi.features.nodes.screens.NodeConnections
 import com.bellako.kiwi.features.nodes.screens.NodeOnMap
 import com.bellako.kiwi.features.nodes.screens.distance
+import com.bellako.kiwi.features.nodes.screens.rememberNodeReveal
 import com.bellako.kiwi.features.nodes.screens.screenToMap
 import com.bellako.kiwi.features.users.model.IUsersViewModel
 import com.bellako.kiwi.ui.LocalKiwiColors
@@ -87,6 +91,14 @@ fun MapScreen(
     val viewportHeightPx =
         with(density) { getScreenHeight().dp.toPx() } * 0.84f // approximate usable space
     val viewportWidthPx = with(density) { getScreenWidth().dp.toPx() }
+
+    var revealStarted by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        listenToEvent(EventType.MAP_REVEAL) {
+            revealStarted = true
+        }
+    }
 
     val mapState by mapViewModel.state.collectAsState()
     val imageBitmap = ImageBitmap.imageResource(id = mapState.mapInfo.mapResourceId)
@@ -156,6 +168,7 @@ fun MapScreen(
                 mapViewModel = mapViewModel,
                 nodesViewModel = nodesViewModel,
                 currentPoints = currentPoints,
+                revealStarted = revealStarted,
                 modifier = Modifier.fillMaxSize(),
             )
         }
@@ -197,11 +210,24 @@ private fun InteractiveMap(
     mapViewModel: MapViewModel,
     nodesViewModel: INodesViewModel,
     currentPoints: Int,
+    revealStarted: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val mapState by mapViewModel.state.collectAsState()
     val nodesState by nodesViewModel.state.collectAsState()
+    val revealConsumed by mapViewModel.revealConsumed.collectAsState()
+
+    val nodesMap = nodesState?.nodes.orEmpty()
+    val focusedNodeId = mapState.selectedNodeId ?: mapState.playerNode.takeIf { it != 0L }
+    val (revealSchedule, revealClockMs) =
+        rememberNodeReveal(
+            nodes = nodesMap,
+            rootNodeId = focusedNodeId,
+            started = revealStarted,
+            alreadyPlayed = revealConsumed,
+            onRevealConsumed = mapViewModel::markRevealConsumed,
+        )
 
     Box(
         modifier =
@@ -283,19 +309,23 @@ private fun InteractiveMap(
 
             // NODE CONNECTIONS
             NodeConnections(
-                nodes = nodesState?.nodes.orEmpty(),
+                nodes = nodesMap,
                 mapState = mapState,
                 modifier = Modifier.fillMaxSize(),
+                edgeReveal = { fromId, toId ->
+                    revealSchedule.edgeReveal(fromId, toId, revealClockMs)
+                },
             )
         }
 
         // NODES
-        nodesState?.nodes?.values?.forEach { node ->
+        nodesMap.values.forEach { node ->
             NodeOnMap(
                 node = node,
                 mapState = mapState,
                 isPlayerNode = node.id == mapState.playerNode,
                 isSelected = node.id == mapState.selectedNodeId,
+                revealScale = revealSchedule.nodeScale(node.id, revealClockMs),
             )
         }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.graphicsLayer
@@ -326,6 +327,7 @@ private fun InteractiveMap(
                 isPlayerNode = node.id == mapState.playerNode,
                 isSelected = node.id == mapState.selectedNodeId,
                 revealScale = revealSchedule.nodeScale(node.id, revealClockMs),
+                nameAlpha = revealSchedule.labelAlpha(node.id, revealClockMs),
             )
         }
 
@@ -337,8 +339,12 @@ private fun InteractiveMap(
                     ?.let { selectedNode ->
                         AudioManager.playSFX(context, R.raw.snd_fx_04_seleccion)
 
+                        // Same gating as the node's label: stay hidden until the
+                        // focused node's pop has finished, then fade in.
+                        val actionAlpha = revealSchedule.labelAlpha(selectedNodeId, revealClockMs)
+
                         Box(
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier.fillMaxSize().alpha(actionAlpha),
                             contentAlignment = Alignment.TopCenter,
                         ) {
                             val centerOffset =

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeEntryTransition.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeEntryTransition.kt
@@ -1,0 +1,110 @@
+package com.bellako.kiwi.features.nodes.screens
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import kotlinx.coroutines.delay
+
+private const val WHITE_FADE_IN_MS = 800
+private const val WHITE_FADE_OUT_MS = 500
+private const val WHITE_HOLD_MS = 450L
+
+/**
+ * Plays a fullscreen white-veil transition between leaving a node and starting
+ * the next sequence (conversation, combat, future features). The veil fades in
+ * slowly, sits at full white for a beat, and is then lifted by the caller once
+ * the follow-up sequence is mounted.
+ *
+ * Decoupled by design — the controller knows nothing about what comes after
+ * the whiteout. Wire it once at the app shell and any node-bearing screen can
+ * trigger a transition without coupling to specific follow-up sequences.
+ */
+@Stable
+class NodeEntryTransitionController internal constructor(
+    private val whiteAlphaAnim: Animatable<Float, AnimationVector1D>,
+) {
+    /** Alpha of the fullscreen white veil. 0f when idle. */
+    val whiteAlpha: Float get() = whiteAlphaAnim.value
+
+    /**
+     * Fades the white veil in and holds it at full white briefly so the
+     * transition reads as a beat rather than a flicker. Returns once the hold
+     * is done — at that point the caller should mount the follow-up sequence
+     * and call [fadeOut] to lift the veil.
+     */
+    suspend fun enter() {
+        whiteAlphaAnim.snapTo(0f)
+        whiteAlphaAnim.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(WHITE_FADE_IN_MS, easing = LinearEasing),
+        )
+        delay(WHITE_HOLD_MS)
+    }
+
+    /**
+     * Fades the white veil back out. Idempotent — calling it while the veil
+     * is already gone is a no-op, so a follow-up screen can dismiss the veil
+     * on its own timing without racing the caller's fallback dismiss.
+     */
+    suspend fun fadeOut() {
+        if (whiteAlphaAnim.value <= 0f) return
+        whiteAlphaAnim.animateTo(
+            targetValue = 0f,
+            animationSpec = tween(WHITE_FADE_OUT_MS, easing = LinearEasing),
+        )
+    }
+}
+
+@Composable
+fun rememberNodeEntryTransitionController(): NodeEntryTransitionController {
+    val alphaAnim = remember { Animatable(0f) }
+    return remember { NodeEntryTransitionController(alphaAnim) }
+}
+
+/**
+ * Provides the active [NodeEntryTransitionController] to descendants. Anything
+ * inside the provider can call [LocalNodeEntryTransition].current to trigger
+ * the transition.
+ */
+val LocalNodeEntryTransition =
+    compositionLocalOf<NodeEntryTransitionController?> { null }
+
+/**
+ * Fullscreen white veil driven by [controller]. Renders nothing while idle so
+ * it doesn't intercept input; once visible it swallows clicks so the user
+ * can't tap through the transition.
+ */
+@Composable
+fun NodeEntryWhiteoutOverlay(
+    controller: NodeEntryTransitionController,
+    modifier: Modifier = Modifier,
+) {
+    val alpha = controller.whiteAlpha
+    if (alpha <= 0f) return
+    val interactionSource = remember { MutableInteractionSource() }
+    Box(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .alpha(alpha)
+                .background(Color.White)
+                .clickable(
+                    interactionSource = interactionSource,
+                    indication = null,
+                    onClick = {},
+                ),
+    )
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeEntryTransition.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeEntryTransition.kt
@@ -18,52 +18,54 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import kotlinx.coroutines.delay
 
-private const val WHITE_FADE_IN_MS = 800
-private const val WHITE_FADE_OUT_MS = 500
-private const val WHITE_HOLD_MS = 450L
+private const val VEIL_FADE_IN_MS = 800
+private const val VEIL_FADE_OUT_MS = 500
+private const val VEIL_HOLD_MS = 450L
+
+private val VEIL_COLOR = Color.Black
 
 /**
- * Plays a fullscreen white-veil transition between leaving a node and starting
- * the next sequence (conversation, combat, future features). The veil fades in
- * slowly, sits at full white for a beat, and is then lifted by the caller once
- * the follow-up sequence is mounted.
+ * Plays a fullscreen veil transition between leaving a node and starting the
+ * next sequence (conversation, combat, future features). The veil fades in
+ * slowly, sits at full opacity for a beat, and is then lifted by the caller
+ * once the follow-up sequence is mounted.
  *
  * Decoupled by design — the controller knows nothing about what comes after
- * the whiteout. Wire it once at the app shell and any node-bearing screen can
+ * the veil. Wire it once at the app shell and any node-bearing screen can
  * trigger a transition without coupling to specific follow-up sequences.
  */
 @Stable
 class NodeEntryTransitionController internal constructor(
-    private val whiteAlphaAnim: Animatable<Float, AnimationVector1D>,
+    private val veilAlphaAnim: Animatable<Float, AnimationVector1D>,
 ) {
-    /** Alpha of the fullscreen white veil. 0f when idle. */
-    val whiteAlpha: Float get() = whiteAlphaAnim.value
+    /** Alpha of the fullscreen veil. 0f when idle. */
+    val veilAlpha: Float get() = veilAlphaAnim.value
 
     /**
-     * Fades the white veil in and holds it at full white briefly so the
+     * Fades the veil in and holds it at full opacity briefly so the
      * transition reads as a beat rather than a flicker. Returns once the hold
      * is done — at that point the caller should mount the follow-up sequence
      * and call [fadeOut] to lift the veil.
      */
     suspend fun enter() {
-        whiteAlphaAnim.snapTo(0f)
-        whiteAlphaAnim.animateTo(
+        veilAlphaAnim.snapTo(0f)
+        veilAlphaAnim.animateTo(
             targetValue = 1f,
-            animationSpec = tween(WHITE_FADE_IN_MS, easing = LinearEasing),
+            animationSpec = tween(VEIL_FADE_IN_MS, easing = LinearEasing),
         )
-        delay(WHITE_HOLD_MS)
+        delay(VEIL_HOLD_MS)
     }
 
     /**
-     * Fades the white veil back out. Idempotent — calling it while the veil
-     * is already gone is a no-op, so a follow-up screen can dismiss the veil
-     * on its own timing without racing the caller's fallback dismiss.
+     * Fades the veil back out. Idempotent — calling it while the veil is
+     * already gone is a no-op, so a follow-up screen can dismiss the veil on
+     * its own timing without racing the caller's fallback dismiss.
      */
     suspend fun fadeOut() {
-        if (whiteAlphaAnim.value <= 0f) return
-        whiteAlphaAnim.animateTo(
+        if (veilAlphaAnim.value <= 0f) return
+        veilAlphaAnim.animateTo(
             targetValue = 0f,
-            animationSpec = tween(WHITE_FADE_OUT_MS, easing = LinearEasing),
+            animationSpec = tween(VEIL_FADE_OUT_MS, easing = LinearEasing),
         )
     }
 }
@@ -83,16 +85,16 @@ val LocalNodeEntryTransition =
     compositionLocalOf<NodeEntryTransitionController?> { null }
 
 /**
- * Fullscreen white veil driven by [controller]. Renders nothing while idle so
- * it doesn't intercept input; once visible it swallows clicks so the user
- * can't tap through the transition.
+ * Fullscreen veil driven by [controller]. Renders nothing while idle so it
+ * doesn't intercept input; once visible it swallows clicks so the user can't
+ * tap through the transition.
  */
 @Composable
-fun NodeEntryWhiteoutOverlay(
+fun NodeEntryVeilOverlay(
     controller: NodeEntryTransitionController,
     modifier: Modifier = Modifier,
 ) {
-    val alpha = controller.whiteAlpha
+    val alpha = controller.veilAlpha
     if (alpha <= 0f) return
     val interactionSource = remember { MutableInteractionSource() }
     Box(
@@ -100,7 +102,7 @@ fun NodeEntryWhiteoutOverlay(
             modifier
                 .fillMaxSize()
                 .alpha(alpha)
-                .background(Color.White)
+                .background(VEIL_COLOR)
                 .clickable(
                     interactionSource = interactionSource,
                     indication = null,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeReveal.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeReveal.kt
@@ -87,8 +87,25 @@ private fun buildNodeRevealSchedule(
 ): NodeRevealSchedule {
     if (nodes.isEmpty()) return NodeRevealSchedule(emptyMap(), 0f)
 
-    // Undirected adjacency so the wave can spread across a connection regardless
-    // of the direction it was declared in.
+    val adjacency = buildUndirectedAdjacency(nodes)
+    val root = pickRootNode(nodes, rootNodeId)
+    val popStart = cascadePopTimes(root, adjacency)
+
+    // Nodes in a disconnected component still appear with the first wave.
+    nodes.keys.forEach { id -> popStart.putIfAbsent(id, 0f) }
+
+    // Run the clock long enough for the last node's label to finish fading.
+    val total = (popStart.values.maxOrNull() ?: 0f) + NODE_POP_MS + LABEL_FADE_MS
+    return NodeRevealSchedule(popStart, total)
+}
+
+/**
+ * Undirected adjacency over [nodes]: the cascade should travel across a
+ * connection regardless of which endpoint declared it.
+ */
+private fun buildUndirectedAdjacency(
+    nodes: Map<Long, NodesDomain>,
+): Map<Long, Set<Long>> {
     val adjacency = HashMap<Long, MutableSet<Long>>()
     nodes.values.forEach { node ->
         node.connectedNodeIds.forEach { other ->
@@ -98,14 +115,36 @@ private fun buildNodeRevealSchedule(
             }
         }
     }
+    return adjacency
+}
 
-    val root =
-        rootNodeId?.takeIf { it in nodes }
-            ?: nodes.keys
-                .filter { id -> nodes.values.none { id in it.connectedNodeIds } }
-                .minOrNull()
-            ?: nodes.keys.min()
+/**
+ * Chooses where the reveal wave originates. Preference order: the explicit
+ * [rootNodeId] (when it still exists), then any node nothing else points at
+ * (i.e. a graph root), then the lowest id as a deterministic fallback.
+ */
+private fun pickRootNode(
+    nodes: Map<Long, NodesDomain>,
+    rootNodeId: Long?,
+): Long {
+    val explicit = rootNodeId?.takeIf { it in nodes }
+    if (explicit != null) return explicit
+    val unreferenced =
+        nodes.keys
+            .filter { id -> nodes.values.none { id in it.connectedNodeIds } }
+            .minOrNull()
+    return unreferenced ?: nodes.keys.min()
+}
 
+/**
+ * BFS over [adjacency] starting at [root]. Returns the earliest pop time for
+ * every reachable node — neighbours of node N pop one (NODE_POP_MS + EDGE_LERP_MS)
+ * later than N does, and re-visits are kept only when they would arrive sooner.
+ */
+private fun cascadePopTimes(
+    root: Long,
+    adjacency: Map<Long, Set<Long>>,
+): HashMap<Long, Float> {
     val popStart = HashMap<Long, Float>()
     val queue = ArrayDeque<Long>()
     popStart[root] = 0f
@@ -123,13 +162,7 @@ private fun buildNodeRevealSchedule(
             }
         }
     }
-
-    // Nodes in a disconnected component still appear with the first wave.
-    nodes.keys.forEach { id -> popStart.putIfAbsent(id, 0f) }
-
-    // Run the clock long enough for the last node's label to finish fading.
-    val total = (popStart.values.maxOrNull() ?: 0f) + NODE_POP_MS + LABEL_FADE_MS
-    return NodeRevealSchedule(popStart, total)
+    return popStart
 }
 
 /**

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeReveal.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeReveal.kt
@@ -15,6 +15,13 @@ import kotlin.math.roundToInt
 
 private const val NODE_POP_MS = 300f
 private const val EDGE_LERP_MS = 240f
+private const val LABEL_FADE_MS = 220f
+
+// A clock value large enough that every node/edge reads as fully revealed for
+// any schedule. Used when the reveal has already played this session, so the
+// populated map shows instantly with no animation and no dependency on which
+// node is focused.
+private const val REVEALED_MS = 1_000_000_000f
 
 /** How a single connecting edge should be drawn at a given moment. */
 data class EdgeReveal(
@@ -27,7 +34,8 @@ data class EdgeReveal(
 /**
  * Precomputed reveal timing for a set of nodes. The wave starts at a chosen
  * root node and cascades outward across the connection graph: a node pops, the
- * edge to a neighbour lerps, and that neighbour pops when the edge reaches it.
+ * edge to a neighbour lerps, that neighbour pops when the edge reaches it, and
+ * a node's label only fades in once its own pop has finished.
  */
 class NodeRevealSchedule(
     private val nodePopStartMs: Map<Long, Float>,
@@ -44,6 +52,15 @@ class NodeRevealSchedule(
             p >= 1f -> 1f
             else -> EaseOutBack.transform(p).coerceAtLeast(0f)
         }
+    }
+
+    /** 0 until the node's pop has fully finished, then fades to 1. */
+    fun labelAlpha(
+        id: Long,
+        clockMs: Float,
+    ): Float {
+        val start = nodePopStartMs[id] ?: return 1f
+        return ((clockMs - (start + NODE_POP_MS)) / LABEL_FADE_MS).coerceIn(0f, 1f)
     }
 
     fun edgeReveal(
@@ -110,7 +127,8 @@ private fun buildNodeRevealSchedule(
     // Nodes in a disconnected component still appear with the first wave.
     nodes.keys.forEach { id -> popStart.putIfAbsent(id, 0f) }
 
-    val total = (popStart.values.maxOrNull() ?: 0f) + NODE_POP_MS
+    // Run the clock long enough for the last node's label to finish fading.
+    val total = (popStart.values.maxOrNull() ?: 0f) + NODE_POP_MS + LABEL_FADE_MS
     return NodeRevealSchedule(popStart, total)
 }
 
@@ -123,6 +141,10 @@ private fun buildNodeRevealSchedule(
  *   is true the map reads as empty.
  * - [onRevealConsumed]: invoked the moment the sequence begins so it is marked
  *   as played for the rest of the session, even if interrupted mid-animation.
+ *
+ * The clock is keyed on topology only (not the focused node), so switching the
+ * focused node recomputes the cascade origin without resetting the clock — no
+ * one-frame disappear/reappear of nodes and edges.
  */
 @Composable
 fun rememberNodeReveal(
@@ -135,17 +157,20 @@ fun rememberNodeReveal(
     val topologyKey =
         nodes.entries
             .sortedBy { it.key }
-            .map { it.key to it.value.connectedNodeIds } to rootNodeId
+            .map { it.key to it.value.connectedNodeIds }
 
-    val schedule = remember(topologyKey) { buildNodeRevealSchedule(nodes, rootNodeId) }
+    val schedule = remember(topologyKey, rootNodeId) { buildNodeRevealSchedule(nodes, rootNodeId) }
     val clock = remember(topologyKey) { Animatable(0f) }
-    var clockMs by remember(topologyKey) { mutableFloatStateOf(0f) }
+    var clockMs by
+        remember(topologyKey) {
+            mutableFloatStateOf(if (alreadyPlayed) REVEALED_MS else 0f)
+        }
     // Snapshot once: flipping the VM flag when we start must NOT restart this.
     val playedAtStart = remember(topologyKey) { alreadyPlayed }
 
     LaunchedEffect(topologyKey, started) {
         if (playedAtStart) {
-            clockMs = schedule.totalDurationMs
+            clockMs = REVEALED_MS
             return@LaunchedEffect
         }
         if (!started || schedule.totalDurationMs <= 0f) {
@@ -167,6 +192,9 @@ fun rememberNodeReveal(
         ) {
             clockMs = value
         }
+        // Saturate so any later focus change (which rebuilds the schedule from a
+        // new origin) still reads as fully revealed.
+        clockMs = REVEALED_MS
     }
 
     return schedule to clockMs

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeReveal.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/NodeReveal.kt
@@ -1,0 +1,173 @@
+package com.bellako.kiwi.features.nodes.screens
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseOutBack
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.bellako.kiwi.features.nodes.data.NodesDomain
+import kotlin.math.roundToInt
+
+private const val NODE_POP_MS = 300f
+private const val EDGE_LERP_MS = 240f
+
+/** How a single connecting edge should be drawn at a given moment. */
+data class EdgeReveal(
+    val fraction: Float,
+    // When true the wave reaches this edge from its `to` endpoint, so it must be
+    // drawn growing from `to` toward `from` instead of the usual `from` -> `to`.
+    val reversed: Boolean,
+)
+
+/**
+ * Precomputed reveal timing for a set of nodes. The wave starts at a chosen
+ * root node and cascades outward across the connection graph: a node pops, the
+ * edge to a neighbour lerps, and that neighbour pops when the edge reaches it.
+ */
+class NodeRevealSchedule(
+    private val nodePopStartMs: Map<Long, Float>,
+    val totalDurationMs: Float,
+) {
+    fun nodeScale(
+        id: Long,
+        clockMs: Float,
+    ): Float {
+        val start = nodePopStartMs[id] ?: return 1f
+        val p = (clockMs - start) / NODE_POP_MS
+        return when {
+            p <= 0f -> 0f
+            p >= 1f -> 1f
+            else -> EaseOutBack.transform(p).coerceAtLeast(0f)
+        }
+    }
+
+    fun edgeReveal(
+        fromId: Long,
+        toId: Long,
+        clockMs: Float,
+    ): EdgeReveal {
+        val fromStart = nodePopStartMs[fromId]
+        val toStart = nodePopStartMs[toId]
+        if (fromStart == null || toStart == null) return EdgeReveal(1f, reversed = false)
+
+        // The wave travels away from whichever endpoint pops first.
+        val reversed = toStart < fromStart
+        val originStart = if (reversed) toStart else fromStart
+        val edgeStart = originStart + NODE_POP_MS
+        val fraction = ((clockMs - edgeStart) / EDGE_LERP_MS).coerceIn(0f, 1f)
+        return EdgeReveal(fraction, reversed)
+    }
+}
+
+private fun buildNodeRevealSchedule(
+    nodes: Map<Long, NodesDomain>,
+    rootNodeId: Long?,
+): NodeRevealSchedule {
+    if (nodes.isEmpty()) return NodeRevealSchedule(emptyMap(), 0f)
+
+    // Undirected adjacency so the wave can spread across a connection regardless
+    // of the direction it was declared in.
+    val adjacency = HashMap<Long, MutableSet<Long>>()
+    nodes.values.forEach { node ->
+        node.connectedNodeIds.forEach { other ->
+            if (other in nodes) {
+                adjacency.getOrPut(node.id) { mutableSetOf() }.add(other)
+                adjacency.getOrPut(other) { mutableSetOf() }.add(node.id)
+            }
+        }
+    }
+
+    val root =
+        rootNodeId?.takeIf { it in nodes }
+            ?: nodes.keys
+                .filter { id -> nodes.values.none { id in it.connectedNodeIds } }
+                .minOrNull()
+            ?: nodes.keys.min()
+
+    val popStart = HashMap<Long, Float>()
+    val queue = ArrayDeque<Long>()
+    popStart[root] = 0f
+    queue.add(root)
+
+    while (queue.isNotEmpty()) {
+        val current = queue.removeFirst()
+        val currentPop = popStart[current] ?: continue
+        val neighbourPop = currentPop + NODE_POP_MS + EDGE_LERP_MS
+        adjacency[current]?.forEach { neighbour ->
+            val existing = popStart[neighbour]
+            if (existing == null || neighbourPop < existing) {
+                popStart[neighbour] = neighbourPop
+                queue.add(neighbour)
+            }
+        }
+    }
+
+    // Nodes in a disconnected component still appear with the first wave.
+    nodes.keys.forEach { id -> popStart.putIfAbsent(id, 0f) }
+
+    val total = (popStart.values.maxOrNull() ?: 0f) + NODE_POP_MS
+    return NodeRevealSchedule(popStart, total)
+}
+
+/**
+ * Builds the reveal schedule cascading from [rootNodeId] and drives the clock.
+ *
+ * - [alreadyPlayed]: the reveal has run once this login session, so show every
+ *   node/edge fully with no animation (e.g. returning from Settings).
+ * - [started]: the gating signal (loading screen finished its exit). Until it
+ *   is true the map reads as empty.
+ * - [onRevealConsumed]: invoked the moment the sequence begins so it is marked
+ *   as played for the rest of the session, even if interrupted mid-animation.
+ */
+@Composable
+fun rememberNodeReveal(
+    nodes: Map<Long, NodesDomain>,
+    rootNodeId: Long?,
+    started: Boolean,
+    alreadyPlayed: Boolean,
+    onRevealConsumed: () -> Unit,
+): Pair<NodeRevealSchedule, Float> {
+    val topologyKey =
+        nodes.entries
+            .sortedBy { it.key }
+            .map { it.key to it.value.connectedNodeIds } to rootNodeId
+
+    val schedule = remember(topologyKey) { buildNodeRevealSchedule(nodes, rootNodeId) }
+    val clock = remember(topologyKey) { Animatable(0f) }
+    var clockMs by remember(topologyKey) { mutableFloatStateOf(0f) }
+    // Snapshot once: flipping the VM flag when we start must NOT restart this.
+    val playedAtStart = remember(topologyKey) { alreadyPlayed }
+
+    LaunchedEffect(topologyKey, started) {
+        if (playedAtStart) {
+            clockMs = schedule.totalDurationMs
+            return@LaunchedEffect
+        }
+        if (!started || schedule.totalDurationMs <= 0f) {
+            clock.snapTo(0f)
+            clockMs = 0f
+            return@LaunchedEffect
+        }
+        // Mark consumed as soon as it starts so it never replays or re-hides
+        // later in the session, even if this animation is cut short.
+        onRevealConsumed()
+        clock.snapTo(0f)
+        clock.animateTo(
+            targetValue = schedule.totalDurationMs,
+            animationSpec =
+                tween(
+                    durationMillis = schedule.totalDurationMs.roundToInt(),
+                    easing = LinearEasing,
+                ),
+        ) {
+            clockMs = value
+        }
+    }
+
+    return schedule to clockMs
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
@@ -1,6 +1,11 @@
 package com.bellako.kiwi.features.nodes.screens
 
 import androidx.annotation.DrawableRes
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.EaseInBack
+import androidx.compose.animation.core.EaseOutBack
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -18,8 +23,10 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
@@ -66,6 +73,8 @@ import kotlin.math.roundToInt
 
 private const val NODE_SELECTED_SCALE = 1.6f
 private const val NODE_BASE_SCALE = 0.1f
+private const val ICON_SHRINK_MS = 180
+private const val ICON_POP_MS = 320
 
 @Composable
 fun Node(
@@ -86,6 +95,18 @@ fun Node(
 
     val indicatorOffset = getResponsiveSizeHeight(14.dp) + nodeHeight * nodeScale / 2
     val displayOffset = getResponsiveSizeHeight(10.dp) + nodeHeight * nodeScale / 2
+
+    // Shrink to 0, swap the drawable at the bottom of the pop, then pop back —
+    // so the locked→unlocked icon swap happens behind a scale of 0 instead of
+    // a hard cut.
+    var displayedStatus by remember { mutableStateOf(nodeStatus) }
+    val iconPopScale = remember { Animatable(1f) }
+    LaunchedEffect(nodeStatus) {
+        if (nodeStatus == displayedStatus) return@LaunchedEffect
+        iconPopScale.animateTo(0f, tween(durationMillis = ICON_SHRINK_MS, easing = EaseInBack))
+        displayedStatus = nodeStatus
+        iconPopScale.animateTo(1f, tween(durationMillis = ICON_POP_MS, easing = EaseOutBack))
+    }
 
     Box(
         modifier =
@@ -112,11 +133,12 @@ fun Node(
                     ),
         ) {
             Kiwi_Image(
-                nodeIcon(nodeStatus, nodeIcon),
+                nodeIcon(displayedStatus, nodeIcon),
                 "node icon",
                 modifier =
                     Modifier
-                        .size(nodeHeight),
+                        .size(nodeHeight)
+                        .scale(iconPopScale.value),
             )
         }
 
@@ -275,6 +297,7 @@ fun NodeConnections(
 
 private val SMALL_NODE_BUTTON = 240.dp
 private val BIG_NODE_BUTTON = 310.dp
+private const val NODE_ACTION_FADE_MS = 240
 
 @Composable
 fun NodeAction(
@@ -322,29 +345,35 @@ fun NodeAction(
                         ),
                     )
                 }
-                when (node.status) {
-                    NodeStatus.LOCKED -> {
-                        UnlockButton("Unlock", currentPoints >= node.price) {
-                            onUnlockNode(
-                                node.id,
-                            )
+                Crossfade(
+                    targetState = node.status,
+                    animationSpec = tween(durationMillis = NODE_ACTION_FADE_MS),
+                    label = "nodeActionButton",
+                ) { status ->
+                    when (status) {
+                        NodeStatus.LOCKED -> {
+                            UnlockButton("Unlock", currentPoints >= node.price) {
+                                onUnlockNode(
+                                    node.id,
+                                )
+                            }
                         }
-                    }
 
-                    NodeStatus.OPEN -> {
-                        PlayButton("Play") {
-                            onCompleteNode(node.id)
+                        NodeStatus.OPEN -> {
+                            PlayButton("Play") {
+                                onCompleteNode(node.id)
+                            }
                         }
-                    }
 
-                    NodeStatus.COMPLETED -> {
-                        PlayButton("Replay") {
-                            onRetryNode(node.id)
-                            replayFirebaseEvent(node.id)
+                        NodeStatus.COMPLETED -> {
+                            PlayButton("Replay") {
+                                onRetryNode(node.id)
+                                replayFirebaseEvent(node.id)
+                            }
                         }
-                    }
 
-                    else -> {}
+                        else -> {}
+                    }
                 }
             }
         }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.geometry.Offset
@@ -75,6 +76,7 @@ fun Node(
     mapScale: Float,
     displayName: String,
     revealScale: Float = 1f,
+    nameAlpha: Float = 1f,
 ) {
     val kiwiColors = LocalKiwiColors.current
 
@@ -133,6 +135,7 @@ fun Node(
             DisplayName(
                 text = displayName,
                 displayOffset = displayOffset,
+                alpha = nameAlpha,
             )
         }
     }
@@ -142,6 +145,7 @@ fun Node(
 fun DisplayName(
     text: String,
     displayOffset: Dp,
+    alpha: Float = 1f,
 ) {
     val kiwiColors = LocalKiwiColors.current
     val shape = RoundedCornerShape(getResponsiveSizeHeight(60.dp))
@@ -158,6 +162,7 @@ fun DisplayName(
         modifier =
             Modifier
                 .offset(y = correctedOffset)
+                .alpha(alpha)
                 .onSizeChanged { heightPx = it.height }
                 .widthIn(max = getResponsiveSizeHeight(260.dp))
                 .background(
@@ -189,6 +194,7 @@ fun NodeOnMap(
     isPlayerNode: Boolean,
     isSelected: Boolean,
     revealScale: Float = 1f,
+    nameAlpha: Float = 1f,
 ) {
     val mapX = node.cordX * mapState.mapWidthPx - mapState.mapWidthPx / 2
     val mapY = (1f - node.cordY) * mapState.mapHeightPx - mapState.mapHeightPx / 2
@@ -209,6 +215,7 @@ fun NodeOnMap(
             mapState.scale,
             node.displayName,
             revealScale,
+            nameAlpha,
         )
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
@@ -74,6 +74,7 @@ fun Node(
     nodeIcon: Int,
     mapScale: Float,
     displayName: String,
+    revealScale: Float = 1f,
 ) {
     val kiwiColors = LocalKiwiColors.current
 
@@ -87,7 +88,7 @@ fun Node(
     Box(
         modifier =
             Modifier
-                .scale(mapScale * NODE_BASE_SCALE),
+                .scale(mapScale * NODE_BASE_SCALE * revealScale),
         contentAlignment = Alignment.Center,
     ) {
         Box(
@@ -187,6 +188,7 @@ fun NodeOnMap(
     mapState: MapState,
     isPlayerNode: Boolean,
     isSelected: Boolean,
+    revealScale: Float = 1f,
 ) {
     val mapX = node.cordX * mapState.mapWidthPx - mapState.mapWidthPx / 2
     val mapY = (1f - node.cordY) * mapState.mapHeightPx - mapState.mapHeightPx / 2
@@ -206,6 +208,7 @@ fun NodeOnMap(
             node.icon,
             mapState.scale,
             node.displayName,
+            revealScale,
         )
     }
 }
@@ -215,6 +218,7 @@ fun NodeConnections(
     nodes: Map<Long, NodesDomain>,
     mapState: MapState,
     modifier: Modifier = Modifier,
+    edgeReveal: (fromId: Long, toId: Long) -> EdgeReveal = { _, _ -> EdgeReveal(1f, reversed = false) },
 ) {
     val kiwiColors = LocalKiwiColors.current
 
@@ -225,8 +229,21 @@ fun NodeConnections(
             from.connectedNodeIds.forEach { toId ->
                 val to = nodes[toId] ?: return@forEach
 
+                val reveal = edgeReveal(from.id, toId)
+                if (reveal.fraction <= 0f) return@forEach
+
                 val fromPos = nodeToScreen(from, mapState)
                 val toPos = nodeToScreen(to, mapState)
+
+                // The wave can reach an edge from either endpoint; grow the line
+                // from the origin endpoint toward the one being revealed.
+                val originPos = if (reveal.reversed) toPos else fromPos
+                val targetPos = if (reveal.reversed) fromPos else toPos
+                val endPos =
+                    Offset(
+                        originPos.x + (targetPos.x - originPos.x) * reveal.fraction,
+                        originPos.y + (targetPos.y - originPos.y) * reveal.fraction,
+                    )
 
                 val color =
                     when (to.status) {
@@ -237,8 +254,8 @@ fun NodeConnections(
 
                 drawLine(
                     color = color,
-                    start = fromPos,
-                    end = toPos,
+                    start = originPos,
+                    end = endPos,
                     strokeWidth = 2.0f,
                     cap = StrokeCap.Butt,
                 )


### PR DESCRIPTION
## Summary

Adds entrance animations to the three major game screens so that navigating through map nodes feels cinematic rather than instantaneous. On first login the map nodes cascade-pop outward from the player's current position using a BFS-ordered wave. Entering a node fades in a full-screen black veil that lifts only once the follow-up screen has its own background fully opaque, preventing any glimpse of the map. Conversations then run a staged intro (background → character slide-in → dialogue → option stagger), and combat plays a three-group sequence (background + veil lift → enemy sprite/health bar/timer → turn indicator/deck stagger/player health bar), with barks withheld until the intro settles.

## Changes

### Game Logic / Other

- **`NodeReveal.kt`** (new) — `NodeRevealSchedule` computes BFS-ordered pop times from a root node; exposes `nodeScale`, `labelAlpha`, and `edgeReveal` driven by a running clock. `rememberNodeReveal` plays the sequence once per login session and skips straight to the end state on re-entry (e.g. returning from Settings).
- **`NodeEntryTransition.kt`** (new) — `NodeEntryTransitionController` (fade-in → hold → `fadeOut()`) and `NodeEntryVeilOverlay` composable. Provided app-wide via `LocalNodeEntryTransition` so any screen can trigger or lift the veil without coupling to its follow-up. Mounted in `MainScreen` inside a `CompositionLocalProvider`.
- **`CombatIntro.kt`** (new) — `CombatIntroController` sequences nine `Animatable` values across three parallel groups; exposes per-slot `skillSlotScale`/`skillSlotAlpha` for the deck stagger and `snapToEnd` for preview/test scenarios.
- **`ConversationScreen.kt`** — replaces the static layout with a `LaunchedEffect`-driven staged intro (bg alpha → character translate → dialogue alpha → options stagger). Liria enters from the bottom; all other characters slide in from the left. Lifts the node-entry veil as soon as the background is fully opaque.
- **`CombatScreen.kt`** — wires `CombatIntroController`; extracts `CombatBottomPanel`; defers `activeBark` display until `intro.isCompleted`; lifts the node-entry veil inside `onBackgroundShown`.
- **`CombatHealthBar.kt`** — adds `barRevealProgress` (centre-expand clip via `centerExpandShape`) and `numbersAlpha` parameters so the bar and its numbers can be revealed independently.
- **`CombatTimer.kt`** — adds `introProgress` to slide the timer panel out from behind the health bar (which renders on top via `zIndex`).
- **`CombatBackground.kt`**, **`CombatBattleArea.kt`**, **`CombatDeck.kt`**, **`CombatPlayerControls.kt`**, **`CombatTurnIndicator.kt`** — each gains intro-specific parameters (`alpha`, `introAlpha`, `slotIntroScale`/`slotIntroAlpha`, etc.) threaded in from `CombatScreen`.
- **`MapScreen.kt`** — uses `NodeRevealSchedule` to drive node/edge/label rendering; replaces `GlobalScope.launch` with `runNodeEntry` to trigger the veil before emitting the node execution event; action panel alpha is gated behind the focused node's label alpha so the button doesn't appear before its node finishes popping.
- **`MapViewModel.kt`** — adds `revealConsumed` state and `markRevealConsumed()` scoped to the HOME back-stack ViewModel (survives Settings navigation, reset on fresh login).
- **`Events.kt`** — adds `MAP_REVEAL` event type to gate the node-reveal clock until the login loading screen has fully exited.
- **`LoginLoadingScreen.kt`** — exposes `onExitComplete` callback; `MainScreen` uses it to emit `MAP_REVEAL`.

## Schema / Migration Notes

No schema changes.

## Testing

1. Log in fresh — the map should reveal with a cascading pop starting from the player's current node. Edges lerp in as the wave travels; labels fade after each node pops.
2. Re-enter the map (e.g. go to Settings and return) — nodes should appear instantly with no animation.
3. Tap a node and confirm — a black veil fades in, then the conversation or combat intro plays sequentially. The veil should lift the moment the follow-up screen's background is fully opaque.
4. In conversation: verify the background fades in, the character sprite slides in, dialogue appears, and options stagger-pop in order.
5. In combat: verify the background fades in first, then the enemy sprite and its health bar (centre-out reveal) and timer (slides out from behind the bar), then the player deck pops slot-by-slot and the player health bar reveals. Barks should only appear after the full intro completes.
6. All flows can be tested against `kiwi_db_dev` with any node that has a linked conversation or combat event.

## Related

None.