### PR TITLE
Improvement/conversations polish

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -42,6 +42,7 @@ import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.features.conversations.components.CharacterName
+import com.bellako.kiwi.features.conversations.components.rememberFloatingModifier
 import com.bellako.kiwi.ui.Kiwi_Theme
 import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
@@ -161,6 +162,9 @@ private fun LoginLoadingContent(
 
     val percent = (progress.coerceIn(0f, 1f) * PERCENT_MULTIPLIER).roundToInt()
 
+    // Liria floats here too — she's an airborne entity wherever she appears.
+    val floatingModifier = rememberFloatingModifier()
+
     BoxWithConstraints(
         modifier =
             modifier
@@ -216,6 +220,7 @@ private fun LoginLoadingContent(
                         Kiwi_Image(
                             R.drawable.character_liria_base,
                             "Liria",
+                            modifier = floatingModifier,
                         )
                     }
                 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/components/IdleAnimation.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/components/IdleAnimation.kt
@@ -1,0 +1,98 @@
+@file:Suppress("MagicNumber")
+
+package com.bellako.kiwi.features.conversations.components
+
+import androidx.compose.animation.core.EaseInOut
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.dp
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+private const val FLOATING_SPRITE_KEY = "liria"
+
+private const val BREATHING_MIN_SCALE = 1f
+private const val BREATHING_MAX_SCALE = 1.02f
+private const val BREATHING_PERIOD_MS = 2200
+
+private const val FLOAT_PERIOD_MS = 4500
+
+private val FULL_TURN_RADIANS = (2.0 * PI).toFloat()
+
+/**
+ * Idle animation for a talking character sprite. Liria is an airborne entity,
+ * so she gets a gentle floating orbit; every other character "breathes" in
+ * place. The choice is driven off the sprite name so both conversation
+ * layouts pick the right idle without extra plumbing.
+ */
+@Composable
+fun rememberCharacterIdleModifier(sprite: String): Modifier =
+    if (sprite.contains(FLOATING_SPRITE_KEY, ignoreCase = true)) {
+        rememberFloatingModifier()
+    } else {
+        rememberBreathingModifier()
+    }
+
+/**
+ * A subtle, looping scale pulse — as if the character were breathing.
+ * Anchored bottom-center so the character stays planted while the body
+ * gently expands. The animated value is read only inside [graphicsLayer], so
+ * the pulse runs on the draw phase without triggering recomposition.
+ */
+@Composable
+fun rememberBreathingModifier(): Modifier {
+    val transition = rememberInfiniteTransition(label = "breathing")
+    val scale by transition.animateFloat(
+        initialValue = BREATHING_MIN_SCALE,
+        targetValue = BREATHING_MAX_SCALE,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(BREATHING_PERIOD_MS, easing = EaseInOut),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "breathing_scale",
+    )
+    return Modifier.graphicsLayer {
+        scaleX = scale
+        scaleY = scale
+        transformOrigin = TransformOrigin(0.5f, 1f)
+    }
+}
+
+/**
+ * A slow elliptical drift — a "horizontal wheel" — that mimics an airborne
+ * entity floating around as it talks. Horizontal travel is wider than
+ * vertical so the orbit reads as a wheel lying flat. The angle advances
+ * linearly and is read only inside [graphicsLayer], so the orbit runs on the
+ * draw phase without triggering recomposition.
+ */
+@Composable
+fun rememberFloatingModifier(): Modifier {
+    val transition = rememberInfiniteTransition(label = "floating")
+    val angle by transition.animateFloat(
+        initialValue = 0f,
+        targetValue = FULL_TURN_RADIANS,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(FLOAT_PERIOD_MS, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart,
+            ),
+        label = "floating_angle",
+    )
+    val horizontalAmplitude = 14.dp
+    val verticalAmplitude = 6.dp
+    return Modifier.graphicsLayer {
+        translationX = horizontalAmplitude.toPx() * sin(angle)
+        translationY = verticalAmplitude.toPx() * cos(angle)
+    }
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/components/TypewriterText.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/components/TypewriterText.kt
@@ -1,0 +1,99 @@
+package com.bellako.kiwi.features.conversations.components
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+import com.bellako.kiwi.common.screens.components.rememberTextWidthScale
+import kotlinx.coroutines.delay
+
+private const val DEFAULT_CHAR_DELAY_MS = 14L
+private const val LINE_HEIGHT = 1.2f
+
+/**
+ * Drives a character-by-character reveal of [fullText]. The whole string is
+ * always laid out so wrapping never shifts mid-reveal; only the colored prefix
+ * grows. Tapping can cut the reveal short via [skip].
+ */
+@Stable
+class TypewriterState(
+    val fullText: String,
+) {
+    var visibleCharCount by mutableIntStateOf(0)
+        internal set
+
+    val isComplete: Boolean
+        get() = visibleCharCount >= fullText.length
+
+    fun skip() {
+        visibleCharCount = fullText.length
+    }
+}
+
+@Composable
+fun rememberTypewriter(
+    fullText: String,
+    charDelayMs: Long = DEFAULT_CHAR_DELAY_MS,
+    play: Boolean = true,
+): TypewriterState {
+    val state = remember(fullText) { TypewriterState(fullText) }
+
+    LaunchedEffect(state, play) {
+        if (!play) return@LaunchedEffect
+        while (state.visibleCharCount < fullText.length) {
+            delay(charDelayMs)
+            // skip() may have completed the reveal while we were delayed.
+            if (state.visibleCharCount < fullText.length) {
+                state.visibleCharCount += 1
+            }
+        }
+    }
+
+    return state
+}
+
+@Composable
+fun Kiwi_TypewriterText(
+    typewriter: TypewriterState,
+    color: Color,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign = TextAlign.Left,
+) {
+    val scale = rememberTextWidthScale()
+    val bodyStyle = MaterialTheme.typography.bodyMedium
+
+    val annotated =
+        remember(typewriter.fullText, typewriter.visibleCharCount, color) {
+            buildAnnotatedString {
+                append(typewriter.fullText)
+                addStyle(SpanStyle(color = color), 0, typewriter.visibleCharCount)
+                addStyle(
+                    SpanStyle(color = Color.Transparent),
+                    typewriter.visibleCharCount,
+                    typewriter.fullText.length,
+                )
+            }
+        }
+
+    Text(
+        text = annotated,
+        textAlign = textAlign,
+        modifier = modifier,
+        style =
+            bodyStyle.copy(
+                fontSize = (bodyStyle.fontSize.value * scale).sp,
+                lineHeight = (bodyStyle.fontSize.value * scale * LINE_HEIGHT).sp,
+            ),
+    )
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/components/TypewriterText.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/components/TypewriterText.kt
@@ -70,19 +70,49 @@ fun Kiwi_TypewriterText(
     modifier: Modifier = Modifier,
     textAlign: TextAlign = TextAlign.Left,
 ) {
+    DialogueText(
+        fullText = typewriter.fullText,
+        revealedChars = typewriter.visibleCharCount,
+        color = color,
+        modifier = modifier,
+        textAlign = textAlign,
+    )
+}
+
+/** Fully revealed dialogue line — used for the outgoing line while it slides away. */
+@Composable
+fun Kiwi_DialogueText(
+    text: String,
+    color: Color,
+    modifier: Modifier = Modifier,
+    textAlign: TextAlign = TextAlign.Left,
+) {
+    DialogueText(
+        fullText = text,
+        revealedChars = text.length,
+        color = color,
+        modifier = modifier,
+        textAlign = textAlign,
+    )
+}
+
+@Composable
+private fun DialogueText(
+    fullText: String,
+    revealedChars: Int,
+    color: Color,
+    modifier: Modifier,
+    textAlign: TextAlign,
+) {
     val scale = rememberTextWidthScale()
     val bodyStyle = MaterialTheme.typography.bodyMedium
 
     val annotated =
-        remember(typewriter.fullText, typewriter.visibleCharCount, color) {
+        remember(fullText, revealedChars, color) {
             buildAnnotatedString {
-                append(typewriter.fullText)
-                addStyle(SpanStyle(color = color), 0, typewriter.visibleCharCount)
-                addStyle(
-                    SpanStyle(color = Color.Transparent),
-                    typewriter.visibleCharCount,
-                    typewriter.fullText.length,
-                )
+                append(fullText)
+                addStyle(SpanStyle(color = color), 0, revealedChars)
+                addStyle(SpanStyle(color = Color.Transparent), revealedChars, fullText.length)
             }
         }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -31,7 +31,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -47,13 +49,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
-import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
-import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
 import com.bellako.kiwi.features.conversations.components.ConversationOption
+import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
+import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationOptionDomain
 import com.bellako.kiwi.features.conversations.data.ConversationType
@@ -107,10 +109,20 @@ fun ConversationScreen(
     val dialogueAlpha = remember { Animatable(0f) }
     val optionsClockMs = remember { Animatable(0f) }
 
+    // Held back until the dialogue stage of the intro sequence so the text
+    // doesn't finish typing before the dialogue box has faded in.
+    var dialogueStageStarted by remember { mutableStateOf(false) }
+    val typewriter = rememberTypewriter(conversation.dialog, play = dialogueStageStarted)
+
     val optionsTotalMs =
         OPTION_POP_MS + (conversation.options.size - 1).coerceAtLeast(0) * OPTION_STAGGER_MS
 
     val nodeEntry = LocalNodeEntryTransition.current
+
+    val advance: () -> Unit = {
+        AudioManager.playSFX(context, R.raw.snd_fx_03_page)
+        viewModel?.next()
+    }
 
     LaunchedEffect(Unit) {
         bgAlpha.animateTo(1f, tween(BG_FADE_MS, easing = LinearEasing))
@@ -121,6 +133,7 @@ fun ConversationScreen(
         delay(STAGE_GAP_MS)
         characterProgress.animateTo(1f, tween(CHARACTER_LERP_MS, easing = FastOutSlowInEasing))
         delay(STAGE_GAP_MS)
+        dialogueStageStarted = true
         dialogueAlpha.animateTo(1f, tween(DIALOGUE_FADE_MS, easing = LinearEasing))
         delay(STAGE_GAP_MS)
         optionsClockMs.animateTo(
@@ -150,7 +163,12 @@ fun ConversationScreen(
             modifier =
                 Modifier
                     .fillMaxSize()
-                    .clickable {},
+                    .clickable {
+                        when {
+                            !typewriter.isComplete -> typewriter.skip()
+                            conversation.options.isEmpty() -> advance()
+                        }
+                    },
         ) {
             val charExtraX =
                 if (isProtagonist) 0.dp else -screenWidth * (1f - characterProgress.value)
@@ -198,14 +216,11 @@ fun ConversationScreen(
                         contentScale = ContentScale.FillWidth,
                         modifier = Modifier.fillMaxWidth(),
                     )
-                    Kiwi_P2(
-                        KiwiTextArguments(
-                            conversation.dialog,
-                            textAlign = TextAlign.Center,
-                            color = if (conversation.dark) kiwiColor.color6 else kiwiColor.color3,
-                            modifier =
-                                Modifier.padding(Spacing.medium, Spacing.medium),
-                        ),
+                    Kiwi_TypewriterText(
+                        typewriter = typewriter,
+                        textAlign = TextAlign.Center,
+                        color = if (conversation.dark) kiwiColor.color6 else kiwiColor.color3,
+                        modifier = Modifier.padding(Spacing.medium, Spacing.medium),
                     )
                     Box(
                         modifier =
@@ -222,14 +237,12 @@ fun ConversationScreen(
                 alpha = dialogueAlpha.value,
                 optionsClockMs = optionsClockMs.value,
                 arrowBounceOffsetY = offsetY,
+                arrowVisible = typewriter.isComplete,
                 onOptionClick = { option ->
                     AudioManager.playSFX(context, R.raw.snd_fx_03_page)
                     viewModel?.next(option)
                 },
-                onAdvance = {
-                    AudioManager.playSFX(context, R.raw.snd_fx_03_page)
-                    viewModel?.next()
-                },
+                onAdvance = advance,
             )
         }
     }
@@ -242,6 +255,7 @@ private fun ConversationOptionsPanel(
     alpha: Float,
     optionsClockMs: Float,
     arrowBounceOffsetY: Float,
+    arrowVisible: Boolean,
     onOptionClick: (ConversationOptionDomain) -> Unit,
     onAdvance: () -> Unit,
 ) {
@@ -275,6 +289,8 @@ private fun ConversationOptionsPanel(
             }
         }
         if (options.isEmpty()) {
+            // Space stays reserved so the panel doesn't jump when the arrow
+            // fades in after the typewriter finishes.
             Kiwi_Spacer(Spacing.medium)
             Kiwi_Image(
                 R.drawable.ic_dialogue_arrow,
@@ -284,7 +300,8 @@ private fun ConversationOptionsPanel(
                         .fillMaxWidth()
                         .size(getResponsiveSizeWidth(8.dp), getResponsiveSizeHeight(8.dp))
                         .offset(y = getResponsiveSizeHeight(arrowBounceOffsetY.dp))
-                        .clickable(onClick = onAdvance),
+                        .alpha(if (arrowVisible) 1f else 0f)
+                        .then(if (arrowVisible) Modifier.clickable(onClick = onAdvance) else Modifier),
             )
             Kiwi_Spacer(Spacing.large)
         } else {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -62,6 +62,7 @@ import com.bellako.kiwi.features.conversations.components.ConversationOption
 import com.bellako.kiwi.features.conversations.components.Kiwi_DialogueText
 import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
 import com.bellako.kiwi.features.conversations.components.TypewriterState
+import com.bellako.kiwi.features.conversations.components.rememberCharacterIdleModifier
 import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationOptionDomain
@@ -120,6 +121,8 @@ fun ConversationScreen(
     // doesn't finish typing before the dialogue box has faded in.
     var dialogueStageStarted by remember { mutableStateOf(false) }
     val typewriter = rememberTypewriter(conversation.dialog, play = dialogueStageStarted)
+
+    val idleModifier = rememberCharacterIdleModifier(conversation.sprite)
 
     val optionsTotalMs =
         OPTION_POP_MS + (conversation.options.size - 1).coerceAtLeast(0) * OPTION_STAGGER_MS
@@ -197,6 +200,7 @@ fun ConversationScreen(
                     painterResourceId =
                         AssetResolver.drawableOr(context, conversation.sprite, R.drawable.character_liria_base),
                     alt = "Character Pose",
+                    modifier = idleModifier,
                 )
             }
             DialogueBox(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -3,6 +3,7 @@ package com.bellako.kiwi.features.conversations.screens
 import android.content.Context
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.EaseOutBack
@@ -13,6 +14,9 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -37,6 +41,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -54,7 +59,9 @@ import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
 import com.bellako.kiwi.features.conversations.components.ConversationOption
+import com.bellako.kiwi.features.conversations.components.Kiwi_DialogueText
 import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
+import com.bellako.kiwi.features.conversations.components.TypewriterState
 import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationOptionDomain
@@ -74,6 +81,7 @@ private const val DIALOGUE_FADE_MS = 600
 private const val OPTION_POP_MS = 450
 private const val OPTION_STAGGER_MS = 140
 private const val STAGE_GAP_MS = 250L
+private const val DIALOGUE_ADVANCE_MS = 450
 
 private const val PROTAGONIST_SPRITE_KEY = "liria"
 
@@ -83,7 +91,6 @@ fun ConversationScreen(
     conversation: ConversationDomain,
     viewModel: ConversationViewModel? = null,
 ) {
-    val kiwiColor = LocalKiwiColors.current
     val infiniteTransition = rememberInfiniteTransition(label = "arrow_bounce")
     val offsetY by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -192,46 +199,11 @@ fun ConversationScreen(
                     alt = "Character Pose",
                 )
             }
-            // Dialogue
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .alpha(dialogueAlpha.value)
-                        .background(
-                            Brush.verticalGradient(
-                                -0.2f to Color.Transparent,
-                                0.5f to kiwiColor.color2,
-                                1f to kiwiColor.color2,
-                            ),
-                        ),
-            ) {
-                Box(
-                    contentAlignment = Alignment.Center,
-                    modifier = Modifier.padding(horizontal = Spacing.medium),
-                ) {
-                    Kiwi_Image(
-                        painterResourceId = getAsset(conversation, R.drawable.dialogue_light_small, LocalContext.current),
-                        alt = "Conversation modal",
-                        contentScale = ContentScale.FillWidth,
-                        modifier = Modifier.fillMaxWidth(),
-                    )
-                    Kiwi_TypewriterText(
-                        typewriter = typewriter,
-                        textAlign = TextAlign.Center,
-                        color = if (conversation.dark) kiwiColor.color6 else kiwiColor.color3,
-                        modifier = Modifier.padding(Spacing.medium, Spacing.medium),
-                    )
-                    Box(
-                        modifier =
-                            Modifier
-                                .matchParentSize()
-                                .offset(x = getResponsiveSizeWidth(25.dp)),
-                    ) {
-                        CharacterName("Liria", conversation.dark, false)
-                    }
-                }
-            }
+            DialogueBox(
+                conversation = conversation,
+                typewriter = typewriter,
+                alpha = dialogueAlpha.value,
+            )
             ConversationOptionsPanel(
                 options = conversation.options,
                 alpha = dialogueAlpha.value,
@@ -244,6 +216,104 @@ fun ConversationScreen(
                 },
                 onAdvance = advance,
             )
+        }
+    }
+}
+
+@Composable
+@Suppress("MagicNumber")
+private fun DialogueBox(
+    conversation: ConversationDomain,
+    typewriter: TypewriterState,
+    alpha: Float,
+    modifier: Modifier = Modifier,
+) {
+    val kiwiColor = LocalKiwiColors.current
+    val context = LocalContext.current
+    Box(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .alpha(alpha)
+                .background(
+                    Brush.verticalGradient(
+                        -0.2f to Color.Transparent,
+                        0.5f to kiwiColor.color2,
+                        1f to kiwiColor.color2,
+                    ),
+                ),
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.padding(horizontal = Spacing.medium),
+        ) {
+            Kiwi_Image(
+                painterResourceId = getAsset(conversation, R.drawable.dialogue_light_small, context),
+                alt = "Conversation modal",
+                contentScale = ContentScale.FillWidth,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            AdvancingDialogueText(
+                conversation = conversation,
+                typewriter = typewriter,
+                modifier = Modifier.matchParentSize(),
+            )
+            Box(
+                modifier =
+                    Modifier
+                        .matchParentSize()
+                        .offset(x = getResponsiveSizeWidth(25.dp)),
+            ) {
+                CharacterName("Liria", conversation.dark, false)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AdvancingDialogueText(
+    conversation: ConversationDomain,
+    typewriter: TypewriterState,
+    modifier: Modifier = Modifier,
+) {
+    val kiwiColor = LocalKiwiColors.current
+    // Scroll-up advance: the current line slides up and out the top while the
+    // next line rises in from the bottom. clipToBounds keeps both inside the
+    // dialogue box so nothing shows over the background.
+    AnimatedContent(
+        targetState = conversation,
+        transitionSpec = {
+            slideInVertically(tween(DIALOGUE_ADVANCE_MS)) { it } togetherWith
+                slideOutVertically(tween(DIALOGUE_ADVANCE_MS)) { -it }
+        },
+        contentKey = { it.id },
+        contentAlignment = Alignment.Center,
+        modifier = modifier.clipToBounds(),
+        label = "dialogue_advance",
+    ) { conv ->
+        val textColor = if (conv.dark) kiwiColor.color6 else kiwiColor.color3
+        val textModifier = Modifier.padding(Spacing.medium, Spacing.medium)
+        // Fill the box so the slide travels the full box height and each line
+        // clears the masked region completely.
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            if (conv.id == conversation.id) {
+                Kiwi_TypewriterText(
+                    typewriter = typewriter,
+                    textAlign = TextAlign.Center,
+                    color = textColor,
+                    modifier = textModifier,
+                )
+            } else {
+                Kiwi_DialogueText(
+                    text = conv.dialog,
+                    textAlign = TextAlign.Center,
+                    color = textColor,
+                    modifier = textModifier,
+                )
+            }
         }
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
@@ -47,6 +47,7 @@ import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
 import com.bellako.kiwi.features.conversations.components.Kiwi_DialogueText
 import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
+import com.bellako.kiwi.features.conversations.components.rememberBreathingModifier
 import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationType
@@ -84,6 +85,10 @@ fun DialogueScreen(
     val context = LocalContext.current
 
     val typewriter = rememberTypewriter(conversation.dialog)
+
+    // The compact dialogue always breathes — even Liria — since the small
+    // circular portrait has no room to read a floating orbit.
+    val breathingModifier = rememberBreathingModifier()
 
     val advance: () -> Unit = {
         AudioManager.playSFX(context, R.raw.snd_fx_03_page)
@@ -126,7 +131,8 @@ fun DialogueScreen(
                             Modifier
                                 .matchParentSize()
                                 .scale(1.6f)
-                                .background(kiwiColor.color0),
+                                .background(kiwiColor.color0)
+                                .then(breathingModifier),
                     )
                 }
                 Kiwi_Image(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
@@ -35,12 +36,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
-import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
-import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer_Horizontal
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
+import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
+import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationType
 import com.bellako.kiwi.features.conversations.data.NextEventType
@@ -74,12 +75,21 @@ fun DialogueScreen(
 
     val context = LocalContext.current
 
+    val typewriter = rememberTypewriter(conversation.dialog)
+
+    val advance: () -> Unit = {
+        AudioManager.playSFX(context, R.raw.snd_fx_03_page)
+        viewModel?.next()
+    }
+
     Column(
         verticalArrangement = Arrangement.Bottom,
         modifier =
             Modifier
                 .fillMaxSize()
-                .clickable {},
+                .clickable {
+                    if (typewriter.isComplete) advance() else typewriter.skip()
+                },
     ) {
         Row(
             horizontalArrangement = Arrangement.SpaceEvenly,
@@ -132,13 +142,11 @@ fun DialogueScreen(
                     "Dialogue frame",
                     contentScale = ContentScale.FillWidth,
                 )
-                Kiwi_P2(
-                    KiwiTextArguments(
-                        conversation.dialog,
-                        textAlign = TextAlign.Center,
-                        color = kiwiColor.color6,
-                        modifier = Modifier.padding(Spacing.medium, Spacing.medium),
-                    ),
+                Kiwi_TypewriterText(
+                    typewriter = typewriter,
+                    textAlign = TextAlign.Center,
+                    color = kiwiColor.color6,
+                    modifier = Modifier.padding(Spacing.medium, Spacing.medium),
                 )
                 Kiwi_Image(
                     R.drawable.ic_dialogue_arrow,
@@ -149,10 +157,14 @@ fun DialogueScreen(
                             .align(Alignment.BottomCenter)
                             .size(getResponsiveSizeWidth(10.dp), getResponsiveSizeHeight(10.dp))
                             .offset(y = getResponsiveSizeHeight(offsetY.dp))
-                            .clickable {
-                                AudioManager.playSFX(context, R.raw.snd_fx_03_page)
-                                viewModel?.next()
-                            },
+                            .alpha(if (typewriter.isComplete) 1f else 0f)
+                            .then(
+                                if (typewriter.isComplete) {
+                                    Modifier.clickable(onClick = advance)
+                                } else {
+                                    Modifier
+                                },
+                            ),
                 )
             }
         }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
@@ -2,12 +2,16 @@ package com.bellako.kiwi.features.conversations.screens
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -26,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -40,6 +45,7 @@ import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer_Horizontal
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
+import com.bellako.kiwi.features.conversations.components.Kiwi_DialogueText
 import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
 import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
@@ -51,6 +57,8 @@ import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
+
+private const val DIALOGUE_ADVANCE_MS = 450
 
 @Composable
 @Suppress("MagicNumber")
@@ -142,12 +150,44 @@ fun DialogueScreen(
                     "Dialogue frame",
                     contentScale = ContentScale.FillWidth,
                 )
-                Kiwi_TypewriterText(
-                    typewriter = typewriter,
-                    textAlign = TextAlign.Center,
-                    color = kiwiColor.color6,
-                    modifier = Modifier.padding(Spacing.medium, Spacing.medium),
-                )
+                // Scroll-up advance: the current line slides up and out the
+                // top while the next line rises in from the bottom.
+                // clipToBounds keeps both inside the frame, off the BG.
+                AnimatedContent(
+                    targetState = conversation,
+                    transitionSpec = {
+                        slideInVertically(tween(DIALOGUE_ADVANCE_MS)) { it } togetherWith
+                            slideOutVertically(tween(DIALOGUE_ADVANCE_MS)) { -it }
+                    },
+                    contentKey = { it.id },
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier.matchParentSize().clipToBounds(),
+                    label = "dialogue_advance",
+                ) { conv ->
+                    val textModifier = Modifier.padding(Spacing.medium, Spacing.medium)
+                    // Fill the frame so the slide travels the full frame height
+                    // and each line clears the masked region completely.
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier.fillMaxSize(),
+                    ) {
+                        if (conv.id == conversation.id) {
+                            Kiwi_TypewriterText(
+                                typewriter = typewriter,
+                                textAlign = TextAlign.Center,
+                                color = kiwiColor.color6,
+                                modifier = textModifier,
+                            )
+                        } else {
+                            Kiwi_DialogueText(
+                                text = conv.dialog,
+                                textAlign = TextAlign.Center,
+                                color = kiwiColor.color6,
+                                modifier = textModifier,
+                            )
+                        }
+                    }
+                }
                 Kiwi_Image(
                     R.drawable.ic_dialogue_arrow,
                     "Arrow",


### PR DESCRIPTION
## Summary

Polishes the mobile conversation UI with three coordinated animation layers: dialogue text now types out character-by-character via a new `TypewriterState` composable; characters animate while speaking (Liria floats in an elliptical orbit, all other characters breathe with a subtle scale pulse); and advancing to the next dialogue line plays a scroll-up slide transition (`AnimatedContent`) rather than an instant swap. The advance arrow is hidden until the typewriter finishes, and tapping the screen mid-reveal skips to the full text. Liria's floating modifier is also applied on the login loading screen for visual consistency.

## Changes

### Game Logic / Other

- **`IdleAnimation.kt`** (new) — `rememberCharacterIdleModifier(sprite)` dispatches between `rememberFloatingModifier()` (slow elliptical orbit, 4.5 s period) for Liria and `rememberBreathingModifier()` (scale pulse, 2.2 s period, anchored bottom-center) for all other characters. Both run on the draw phase via `graphicsLayer` to avoid recomposition.
- **`TypewriterText.kt`** (new) — `TypewriterState` + `rememberTypewriter()` drive a character-by-character reveal using a `LaunchedEffect` loop. The full string is always laid out (invisible suffix rendered in `Color.Transparent`) so word-wrap never shifts mid-reveal. `TypewriterState.skip()` instantly completes the reveal. `Kiwi_TypewriterText` and `Kiwi_DialogueText` (fully revealed, for the outgoing slide) share a private `DialogueText` composable.
- **`ConversationScreen.kt`** — integrates typewriter and idle modifier; refactors the inline dialogue box into a `DialogueBox` + `AdvancingDialogueText` composable pair. `AnimatedContent` keyed on `conversation.id` provides the slide-up advance transition. Arrow visibility and tap-to-advance are gated on `typewriter.isComplete`.
- **`DialogueScreen.kt`** — same typewriter and slide-up transition for the compact dialogue layout. Always uses `rememberBreathingModifier()` (the circular portrait is too small for Liria's orbit to read correctly).
- **`LoginLoadingScreen.kt`** — applies `rememberFloatingModifier()` to Liria's sprite during the loading sequence.

## Schema / Migration Notes

No schema changes.

## Testing

1. Build and launch the app on a device or emulator.
2. Navigate to any conversation node — confirm dialogue types out character by character (~14 ms/char).
3. Tap mid-reveal — text should jump to fully visible immediately.
4. Wait for or skip the typewriter; confirm the advance arrow fades in only after the reveal completes.
5. Advance to the next line — confirm the old line slides up and out while the new line rises in (450 ms).
6. Open a `DialogueScreen` (compact layout) and repeat steps 2–5.
7. On the login/loading screen, confirm Liria's sprite drifts in a gentle floating orbit.
8. For a non-Liria character in `ConversationScreen`, confirm the breathing pulse (no orbit).

## Related

None.