### PR TITLE
Improvement/combat polish

### DIFF
--- a/backend/src/main/java/com/kiwi/features/combat/controllers/CombatLogService.java
+++ b/backend/src/main/java/com/kiwi/features/combat/controllers/CombatLogService.java
@@ -8,6 +8,7 @@ import com.kiwi.features.combat.repositories.CombatLogRepository;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -76,12 +77,16 @@ public class CombatLogService {
     //------------------------------------------------------------------------------------------------------------------
 
     @Transactional
-    public void saveCombatActions(List<CombatActionDomain> actions, Long combatId, int turnNumber) {
+    public Instant saveCombatActions(List<CombatActionDomain> actions, Long combatId, int turnNumber) {
+        Instant createdAt = Instant.now();
+
         List<CombatLogPersistence> logs = actions.stream()
-                .flatMap(a -> CombatActionMapper.toCombatLogPersistence(a, combatId, turnNumber).stream())
+                .flatMap(a -> CombatActionMapper.toCombatLogPersistence(a, combatId, turnNumber, createdAt).stream())
                 .toList();
 
         combatLogRepository.saveAll(logs);
+
+        return createdAt;
     }
 
     //------------------------------------------------------------------------------------------------------------------

--- a/backend/src/main/java/com/kiwi/features/combat/controllers/CombatTurnService.java
+++ b/backend/src/main/java/com/kiwi/features/combat/controllers/CombatTurnService.java
@@ -16,6 +16,7 @@ import com.kiwi.features.skills.controllers.SkillService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.util.Map;
 
 @Service
@@ -66,7 +67,7 @@ public class CombatTurnService {
 
         CombatTurnResultDomain result = combatEngine.executeTurn(combatDomain, skillId);
 
-        combatLogService.saveCombatActions(result.getActions(), combatPersistence.getId(), combatPersistence.getTurnNumber());
+        Instant createdAt = combatLogService.saveCombatActions(result.getActions(), combatPersistence.getId(), combatPersistence.getTurnNumber());
 
         lastSkillService.updateLastSkills(
                 combatPersistence.getId(),
@@ -87,7 +88,7 @@ public class CombatTurnService {
             skillService.removeCooldown(userId, resetCooldownId);
         }
 
-        return CombatTurnResultMapper.toDTO(result);
+        return CombatTurnResultMapper.toDTO(result, createdAt);
     }
 
     //------------------------------------------------------------------------------------------------------------------
@@ -112,7 +113,7 @@ public class CombatTurnService {
 
             combatProgressService.applyTurnResult(combatPersistence, combatDomain);
 
-            return CombatTurnResultMapper.toDTO(combatEngine.buildTimeoutCombatTurnResult(combatDomain));
+            return CombatTurnResultMapper.toDTO(combatEngine.buildTimeoutCombatTurnResult(combatDomain), Instant.now());
         }
 
         return new CombatTurnResultDTO();
@@ -133,7 +134,7 @@ public class CombatTurnService {
 
         combatProgressService.applyTurnResult(combatPersistence,combatDomain);
 
-        return CombatTurnResultMapper.toDTO(combatEngine.buildAbandonCombatTurnResult(combatDomain));
+        return CombatTurnResultMapper.toDTO(combatEngine.buildAbandonCombatTurnResult(combatDomain), Instant.now());
 
     }
 

--- a/backend/src/main/java/com/kiwi/features/combat/data/dto/CombatTurnResultDTO.java
+++ b/backend/src/main/java/com/kiwi/features/combat/data/dto/CombatTurnResultDTO.java
@@ -2,6 +2,7 @@ package com.kiwi.features.combat.data.dto;
 
 import lombok.*;
 
+import java.time.Instant;
 import java.util.List;
 
 @Getter
@@ -23,5 +24,7 @@ public class CombatTurnResultDTO {
     private int onCompletedEntityId;
 
     private boolean bonusActionPending;
+
+    private Instant createdAt;
 
 }

--- a/backend/src/main/java/com/kiwi/features/combat/data/mappers/CombatActionMapper.java
+++ b/backend/src/main/java/com/kiwi/features/combat/data/mappers/CombatActionMapper.java
@@ -18,18 +18,19 @@ public class CombatActionMapper {
     public static List<CombatLogPersistence> toCombatLogPersistence(
             CombatActionDomain action,
             Long combatId,
-            int turnNumber
+            int turnNumber,
+            Instant createdAt
     ) {
 
         return switch (action.getActionType()) {
 
-            case SKILL_USED -> mapSkillUsed(action, combatId, turnNumber);
+            case SKILL_USED -> mapSkillUsed(action, combatId, turnNumber, createdAt);
 
             case ACTOR_BLOCKED_BY_STATE,
                  SKILL_REPEAT_BY_STATE,
                  STATUS_TURN_REDUCED,
                  STATUS_FINISHED -> List.of(
-                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber)
+                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber, createdAt)
                             .stateName(action.getState()  != null ? action.getState().getName() : null)
                             .stateId(action.getState()  != null ? action.getState().getStateId() : null)
                             .build()
@@ -37,7 +38,7 @@ public class CombatActionMapper {
 
             case ACTOR_HEALED_BY_STATE,
                  ACTOR_DAMAGED_BY_STATE -> List.of(
-                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber)
+                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber, createdAt)
                             .stateName(action.getState()  != null ? action.getState().getName() : null)
                             .stateId(action.getState()  != null ? action.getState().getStateId() : null)
                             .value(action.getStateEffectValue())
@@ -46,7 +47,7 @@ public class CombatActionMapper {
 
             case BLOCKED_SKILLS_BY_STATE,
                  RELEASED_SKILLS_BY_STATE -> List.of(
-                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber)
+                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber, createdAt)
                             .stateName(action.getState()  != null ? action.getState().getName() : null)
                             .stateId(action.getState()  != null ? action.getState().getStateId() : null)
                             .blockedSkills(
@@ -56,7 +57,7 @@ public class CombatActionMapper {
             );
 
             case SKIP, TIMEOUT, ABANDON, ACTOR_SKIPPED_BY_TURNS -> List.of(
-                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber).build()
+                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber, createdAt).build()
             );
         };
     }
@@ -66,12 +67,13 @@ public class CombatActionMapper {
     private static List<CombatLogPersistence> mapSkillUsed(
             CombatActionDomain action,
             Long combatId,
-            int turnNumber
+            int turnNumber,
+            Instant createdAt
     ) {
 
         if (action.getSkillEffectsResults() == null || action.getSkillEffectsResults().isEmpty()) {
             return List.of(
-                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber)
+                    baseCombatLogPersistenceBuilder(action, combatId, turnNumber, createdAt)
                             .skillName(action.getSkillName())
                             .build()
             );
@@ -80,7 +82,7 @@ public class CombatActionMapper {
         return action.getSkillEffectsResults().stream()
                 .map(effect -> {
                     CombatLogPersistence.CombatLogPersistenceBuilder builder =
-                            baseCombatLogPersistenceBuilder(action, combatId, turnNumber)
+                            baseCombatLogPersistenceBuilder(action, combatId, turnNumber, createdAt)
                                     .skillName(action.getSkillName())
                                     .effectType(effect.getTypeResult())
                                     .target(effect.getTarget())
@@ -111,14 +113,15 @@ public class CombatActionMapper {
     private static CombatLogPersistence.CombatLogPersistenceBuilder baseCombatLogPersistenceBuilder(
             CombatActionDomain action,
             Long combatId,
-            int turnNumber
+            int turnNumber,
+            Instant createdAt
     ) {
         return CombatLogPersistence.builder()
                 .combatId(combatId)
                 .turnNumber(turnNumber)
                 .actor(action.getActor() != null ? action.getActor() : null)
                 .combatActionType(action.getActionType() != null ? action.getActionType() : null)
-                .createdAt(Instant.now());
+                .createdAt(createdAt);
     }
 
     //------------------------------------------------------------------------------------------------------------------

--- a/backend/src/main/java/com/kiwi/features/combat/data/mappers/CombatTurnResultMapper.java
+++ b/backend/src/main/java/com/kiwi/features/combat/data/mappers/CombatTurnResultMapper.java
@@ -4,11 +4,12 @@ import com.kiwi.features.combat.data.domain.CombatTurnResultDomain;
 import com.kiwi.features.combat.data.dto.CombatActionDTO;
 import com.kiwi.features.combat.data.dto.CombatTurnResultDTO;
 
+import java.time.Instant;
 import java.util.List;
 
 public class CombatTurnResultMapper {
 
-    public static CombatTurnResultDTO toDTO (CombatTurnResultDomain domain){
+    public static CombatTurnResultDTO toDTO (CombatTurnResultDomain domain, Instant createdAt){
 
         List<CombatActionDTO> actionDTOList = CombatActionMapper.toDTOList(domain.getActions());
 
@@ -18,6 +19,7 @@ public class CombatTurnResultMapper {
                 .actions(actionDTOList)
                 .combatStatus(domain.getCombatStatus().name())
                 .bonusActionPending(domain.isBonusActionPending())
+                .createdAt(createdAt)
                 .build();
     }
 }

--- a/backend/src/test/java/com/kiwi/combat/CombatTestFactory.java
+++ b/backend/src/test/java/com/kiwi/combat/CombatTestFactory.java
@@ -226,6 +226,7 @@ public class CombatTestFactory {
                 .turnNumber(1 + RANDOM.nextInt(10))
                 .actions(List.of())
                 .combatStatus(CombatGeneralStatus.ONGOING.name())
+                .createdAt(Instant.now())
                 .build();
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -41,8 +41,8 @@ import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_P2
+import com.bellako.kiwi.common.screens.components.rememberFloatingModifier
 import com.bellako.kiwi.features.conversations.components.CharacterName
-import com.bellako.kiwi.features.conversations.components.rememberFloatingModifier
 import com.bellako.kiwi.ui.Kiwi_Theme
 import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/IdleAnimation.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/components/IdleAnimation.kt
@@ -1,6 +1,6 @@
 @file:Suppress("MagicNumber")
 
-package com.bellako.kiwi.features.conversations.components
+package com.bellako.kiwi.common.screens.components
 
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.LinearEasing

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatAnimations.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatAnimations.kt
@@ -1,17 +1,46 @@
 package com.bellako.kiwi.features.combat.components
 
 import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 
 private const val BLINK_DIM_ALPHA = 0.35f
 private const val BLINK_FADE_MS = 220
 private const val BLINK_CYCLES = 2
 
+private const val TURN_PULSE_DIM_ALPHA = 0.4f
+private const val TURN_PULSE_HALF_CYCLE_MS = 650
+
 /** Shared blink alpha animator used by combat log entries and the turn indicator. */
 @Composable
 fun rememberBlinkAlpha(): Animatable<Float, *> = remember { Animatable(1f) }
+
+/**
+ * A continuous, gentle alpha pulse used to keep attention on the turn indicator
+ * while it's the player's turn to act. Returns full opacity (1f) when [active]
+ * is false, so callers can multiply it in unconditionally.
+ */
+@Composable
+fun rememberTurnPulseAlpha(active: Boolean): Float {
+    val transition = rememberInfiniteTransition(label = "combat_turn_pulse")
+    val pulse by transition.animateFloat(
+        initialValue = 1f,
+        targetValue = TURN_PULSE_DIM_ALPHA,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(TURN_PULSE_HALF_CYCLE_MS),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "combat_turn_pulse_alpha",
+    )
+    return if (active) pulse else 1f
+}
 
 /** Plays the standard combat blink: snap to full, then dim/restore [BLINK_CYCLES] times. */
 suspend fun Animatable<Float, *>.blink() {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBackground.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBackground.kt
@@ -2,14 +2,19 @@ package com.bellako.kiwi.features.combat.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.ColorMatrix
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
@@ -17,6 +22,9 @@ import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.ui.LocalKiwiColors
 
 private const val BACKGROUND_SATURATION = 0.45f
+// The image is laid out larger than the screen so the damage shake can move it
+// around without ever exposing the backdrop behind it.
+private const val BACKGROUND_OVERSCAN_SCALE = 2f
 private const val EDGE_FADE_TOP_ALPHA = 0.75f
 private const val EDGE_FADE_BOTTOM_ALPHA = 0.95f
 private const val EDGE_FADE_TOP_END = 0.18f
@@ -26,31 +34,50 @@ private const val EDGE_FADE_BOTTOM_START = 0.55f
 internal fun CombatBackground(
     background: String?,
     alpha: Float = 1f,
+    shakeOffsetX: () -> Float = { 0f },
 ) {
     val colors = LocalKiwiColors.current
     val resId = AssetResolver.drawable(LocalContext.current, background) ?: return
-    Kiwi_Image(
-        painterResourceId = resId,
-        alt = "Combat background",
-        modifier = Modifier.fillMaxSize().alpha(alpha),
-        contentScale = ContentScale.Crop,
-        colorFilter =
-            ColorFilter.colorMatrix(
-                ColorMatrix().apply { setToSaturation(BACKGROUND_SATURATION) },
-            ),
-    )
-    Box(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .alpha(alpha)
-                .background(
-                    Brush.verticalGradient(
-                        0f to colors.color2.copy(alpha = EDGE_FADE_TOP_ALPHA),
-                        EDGE_FADE_TOP_END to Color.Transparent,
-                        EDGE_FADE_BOTTOM_START to Color.Transparent,
-                        1f to colors.color2.copy(alpha = EDGE_FADE_BOTTOM_ALPHA),
-                    ),
+    BoxWithConstraints(
+        // A fixed, screen-sized viewport. The oversized image is clipped to it,
+        // so the shake slides the image within the margin instead of exposing
+        // the backdrop at the edges.
+        modifier = Modifier.fillMaxSize().clipToBounds(),
+    ) {
+        Kiwi_Image(
+            painterResourceId = resId,
+            alt = "Combat background",
+            modifier =
+                Modifier
+                    // requiredSize, not size — size would be coerced back to the
+                    // viewport's constraints, leaving the image only screen-sized.
+                    .requiredSize(
+                        maxWidth * BACKGROUND_OVERSCAN_SCALE,
+                        maxHeight * BACKGROUND_OVERSCAN_SCALE,
+                    ).align(Alignment.Center)
+                    // Read inside graphicsLayer so the shake runs on the draw
+                    // phase without recomposing.
+                    .graphicsLayer { translationX = shakeOffsetX() }
+                    .alpha(alpha),
+            contentScale = ContentScale.Crop,
+            colorFilter =
+                ColorFilter.colorMatrix(
+                    ColorMatrix().apply { setToSaturation(BACKGROUND_SATURATION) },
                 ),
-    )
+        )
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .alpha(alpha)
+                    .background(
+                        Brush.verticalGradient(
+                            0f to colors.color2.copy(alpha = EDGE_FADE_TOP_ALPHA),
+                            EDGE_FADE_TOP_END to Color.Transparent,
+                            EDGE_FADE_BOTTOM_START to Color.Transparent,
+                            1f to colors.color2.copy(alpha = EDGE_FADE_BOTTOM_ALPHA),
+                        ),
+                    ),
+        )
+    }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBarkBubble.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBarkBubble.kt
@@ -1,5 +1,6 @@
 package com.bellako.kiwi.features.combat.components
 
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
@@ -18,8 +19,10 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -39,6 +42,7 @@ import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import kotlinx.coroutines.delay
 
 private const val DEFAULT_AUTO_DISMISS_MS = 3000L
+private const val BARK_APPEAR_FADE_MS = 220
 private const val ARROW_BOUNCE_MS = 600
 private const val ARROW_BOUNCE_TARGET = -10f
 private val BARK_MIN_WIDTH = 180.dp
@@ -56,6 +60,14 @@ fun CombatBarkBubble(
     val colors = LocalKiwiColors.current
     val context = LocalContext.current
     val isAuto = bark.dismissMode == BarkDismissMode.AUTO
+
+    // Every bark fades in when it appears. Keyed on triggerId so a back-to-back
+    // bark still plays the fade from scratch.
+    val appearAlpha = remember { Animatable(0f) }
+    LaunchedEffect(bark.triggerId) {
+        appearAlpha.snapTo(0f)
+        appearAlpha.animateTo(1f, tween(BARK_APPEAR_FADE_MS))
+    }
 
     if (isAuto) {
         LaunchedEffect(bark.triggerId) {
@@ -82,6 +94,7 @@ fun CombatBarkBubble(
         horizontalAlignment = Alignment.CenterHorizontally,
         modifier =
             modifier
+                .alpha(appearAlpha.value)
                 .widthIn(
                     min = getResponsiveSizeWidth(BARK_MIN_WIDTH),
                     max = getResponsiveSizeWidth(BARK_MAX_WIDTH),

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBattleArea.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBattleArea.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.zIndex
 import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
+import com.bellako.kiwi.common.screens.components.rememberBreathingModifier
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.combat.data.CombatDomain
 import com.bellako.kiwi.ui.Spacing
@@ -132,6 +133,8 @@ internal fun CombatEnemySprite(
     val spriteAlpha = remember { Animatable(1f) }
     var isDamageAnimating by remember { mutableStateOf(false) }
 
+    val breathingModifier = rememberBreathingModifier()
+
     LaunchedEffect(damageTrigger) {
         if (damageTrigger == 0) return@LaunchedEffect
         isDamageAnimating = true
@@ -170,7 +173,8 @@ internal fun CombatEnemySprite(
             modifier
                 .fillMaxSize()
                 .offset { IntOffset(offsetX.value.roundToInt(), 0) }
-                .alpha(spriteAlpha.value * introAlpha),
+                .alpha(spriteAlpha.value * introAlpha)
+                .then(breathingModifier),
         contentScale = ContentScale.Fit,
         colorFilter =
             if (redAlpha.value > 0f) {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBattleArea.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBattleArea.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
@@ -39,7 +38,6 @@ import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.combat.data.CombatDomain
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
-import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
@@ -47,7 +45,6 @@ import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
 private const val HEALTH_BAR_WIDTH_FRACTION = 0.6f
-private const val LOG_HEIGHT_FRACTION = 0.85f
 private const val DAMAGE_WIGGLE_CYCLES = 4
 private const val DAMAGE_WIGGLE_AMPLITUDE_PX = 22f
 private const val DAMAGE_WIGGLE_STEP_MS = 50
@@ -60,12 +57,8 @@ private const val ENEMY_DEFEAT_FADE_MS = 800
 private const val LOG_DIM_ALPHA = 0.55f
 
 @Composable
-@Suppress("LongParameterList")
 internal fun ColumnScope.CombatBattleArea(
     combat: CombatDomain,
-    isLogOpen: Boolean,
-    onDismissLog: () -> Unit,
-    logEntries: List<CombatLogEntry>,
     enemyBarRevealProgress: Float = 1f,
     enemyBarNumbersAlpha: Float = 1f,
     timerIntroProgress: Float = 1f,
@@ -84,29 +77,6 @@ internal fun ColumnScope.CombatBattleArea(
             barNumbersAlpha = enemyBarNumbersAlpha,
             timerIntroProgress = timerIntroProgress,
         )
-
-        if (isLogOpen) {
-            LogDimOverlay(
-                modifier = Modifier.fillMaxSize(),
-                onDismiss = onDismissLog,
-            )
-
-            CombatLog(
-                entries = logEntries,
-                modifier =
-                    Modifier
-                        .align(Alignment.BottomCenter)
-                        .padding(
-                            horizontal = getResponsiveSizeWidth(Spacing.medium),
-                            vertical = getResponsiveSizeHeight(Spacing.small),
-                        ).fillMaxHeight(LOG_HEIGHT_FRACTION)
-                        .clickable(
-                            indication = null,
-                            interactionSource = remember { MutableInteractionSource() },
-                            onClick = {},
-                        ),
-            )
-        }
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatLog.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatLog.kt
@@ -45,6 +45,7 @@ import androidx.compose.ui.text.AnnotatedString.Builder as AnnotatedStringBuilde
 private val LOG_RADIUS = 12.dp
 private val LOG_INNER_PADDING = 16.dp
 private const val USER_NAME_PLACEHOLDER = "You"
+private const val LOG_BG_ALPHA = 0.85f
 
 sealed class CombatLogEntry {
     data class Action(
@@ -80,7 +81,11 @@ fun CombatLog(
         modifier =
             modifier
                 .fillMaxWidth()
-                .combatPanel(bgColor = colors.color3A, borderColor = colors.color5C, radius = LOG_RADIUS),
+                .combatPanel(
+                    bgColor = colors.color3A.copy(alpha = LOG_BG_ALPHA),
+                    borderColor = colors.color5C,
+                    radius = LOG_RADIUS,
+                ),
     ) {
         LazyColumn(
             state = listState,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatLog.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatLog.kt
@@ -41,10 +41,16 @@ import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import androidx.compose.ui.text.AnnotatedString.Builder as AnnotatedStringBuilder
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 private val LOG_RADIUS = 12.dp
 private val LOG_INNER_PADDING = 16.dp
+// The player as the sentence subject ("You have used...") vs. as the object
+// ("...against you").
 private const val USER_NAME_PLACEHOLDER = "You"
+private const val USER_NAME_PLACEHOLDER_TARGET = "you"
 private const val LOG_BG_ALPHA = 0.85f
 
 sealed class CombatLogEntry {
@@ -52,8 +58,8 @@ sealed class CombatLogEntry {
         val text: AnnotatedString,
     ) : CombatLogEntry()
 
-    data class TurnSeparator(
-        val turnNumber: Int,
+    data class TimeSeparator(
+        val timestampMillis: Long,
     ) : CombatLogEntry()
 
     data class Intro(
@@ -124,17 +130,16 @@ fun CombatLog(
                             ),
                         )
 
-                    is CombatLogEntry.TurnSeparator -> {
-                        Kiwi_Spacer(Spacing.xSmall)
-                        Box(modifier = entryModifier) {
+                    is CombatLogEntry.TimeSeparator ->
+                        Column(modifier = Modifier.fillMaxWidth().then(entryModifier)) {
+                            Kiwi_Spacer(Spacing.xSmall)
                             Kiwi_HorizontalLine_Text(
-                                text = "Turn ${entry.turnNumber}",
+                                text = formatLogTime(entry.timestampMillis),
                                 color = colors.color5C,
                                 textColor = colors.color7A,
                             )
+                            Kiwi_Spacer(Spacing.xSmall)
                         }
-                        Kiwi_Spacer(Spacing.xSmall)
-                    }
                 }
             }
         }
@@ -161,7 +166,16 @@ fun buildCombatLogEntries(
             )
     }
 
+    // A timestamp separator opens each turn group — i.e. whenever the backend
+    // turn time changes. Actions with no timestamp (a combat's initial log)
+    // simply get no separator.
+    var lastTimestamp: Long? = null
     actions.forEach { action ->
+        val timestamp = action.createdAt
+        if (timestamp != null && timestamp != lastTimestamp) {
+            result += CombatLogEntry.TimeSeparator(timestamp)
+            lastTimestamp = timestamp
+        }
         result += CombatLogEntry.Action(formatAction(action, enemyName, colors))
     }
 
@@ -191,81 +205,86 @@ private fun formatAction(
     enemyName: String,
     colors: KiwiColorsData,
 ): AnnotatedString {
-    val actorName = if (action.actor == CombatActor.USER) USER_NAME_PLACEHOLDER else enemyName
+    val actorIsUser = action.actor == CombatActor.USER
+    val actorName = if (actorIsUser) USER_NAME_PLACEHOLDER else enemyName
+    val targetActor = if (actorIsUser) CombatActor.ENEMY else CombatActor.USER
+    val targetName = if (actorIsUser) enemyName else USER_NAME_PLACEHOLDER_TARGET
     return buildAnnotatedString {
         when (action.actionType) {
             CombatActionType.SKILL_USED -> {
-                appendActor(actorName, colors)
-                append(" used ")
-                action.skillName?.let { appendSkill(it, colors) }
-                append("!")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(if (actorIsUser) " have used " else " has used ", colors)
+                action.skillName?.let { appendSkill(it, action.actor, colors) }
+                appendNarrative(" against ", colors)
+                appendActor(targetName, targetActor, colors)
+                appendNarrative(".", colors)
             }
 
             CombatActionType.ACTOR_BLOCKED_BY_STATE -> {
-                appendActor(actorName, colors)
-                append(" is blocked by ")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(" is blocked by ", colors)
                 appendStatus(action.stateName, colors)
-                append(".")
+                appendNarrative(".", colors)
             }
 
             CombatActionType.SKILL_REPEAT_BY_STATE -> {
-                appendActor(actorName, colors)
-                append(" repeats ")
-                action.skillName?.let { appendSkill(it, colors) }
-                append(" because of ")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(" repeats ", colors)
+                action.skillName?.let { appendSkill(it, action.actor, colors) }
+                appendNarrative(" because of ", colors)
                 appendStatus(action.stateName, colors)
-                append(".")
+                appendNarrative(".", colors)
             }
 
             CombatActionType.ACTOR_DAMAGED_BY_STATE -> {
-                appendActor(actorName, colors)
-                append(" suffers from ")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(" suffers from ", colors)
                 appendStatus(action.stateName, colors)
-                append(".")
+                appendNarrative(".", colors)
             }
 
             CombatActionType.BLOCKED_SKILLS_BY_STATE -> {
-                appendActor(actorName, colors)
-                append("'s skills are blocked by ")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative("'s skills are blocked by ", colors)
                 appendStatus(action.stateName, colors)
-                append(".")
+                appendNarrative(".", colors)
             }
 
             CombatActionType.RELEASED_SKILLS_BY_STATE -> {
-                appendActor(actorName, colors)
-                append("'s skills are released from ")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative("'s skills are released from ", colors)
                 appendStatus(action.stateName, colors)
-                append(".")
+                appendNarrative(".", colors)
             }
 
             CombatActionType.SKIP -> {
-                appendActor(actorName, colors)
-                append(" skipped the turn.")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(" skipped the turn.", colors)
             }
 
             CombatActionType.ACTOR_SKIPPED_BY_TURNS -> {
-                appendActor(actorName, colors)
-                append("'s turn was skipped!")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative("'s turn was skipped!", colors)
             }
 
             CombatActionType.STATUS_TURN_REDUCED -> {
                 appendStatus(action.stateName, colors)
-                append(" weakens on ")
-                appendActor(actorName, colors)
-                append(".")
+                appendNarrative(" weakens on ", colors)
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(".", colors)
             }
 
             CombatActionType.STATUS_FINISHED -> {
                 appendStatus(action.stateName, colors)
-                append(" wears off on ")
-                appendActor(actorName, colors)
-                append(".")
+                appendNarrative(" wears off on ", colors)
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(".", colors)
             }
 
-            CombatActionType.TIMEOUT -> append("The battle timed out.")
+            CombatActionType.TIMEOUT -> appendNarrative("The battle timed out.", colors)
             CombatActionType.ABANDON -> {
-                appendActor(actorName, colors)
-                append(" abandoned the battle.")
+                appendActor(actorName, action.actor, colors)
+                appendNarrative(" abandoned the battle.", colors)
             }
         }
     }
@@ -273,21 +292,40 @@ private fun formatAction(
 
 private fun AnnotatedStringBuilder.appendActor(
     name: String,
+    actor: CombatActor,
     colors: KiwiColorsData,
 ) {
-    withStyle(SpanStyle(color = colors.color7A, fontStyle = FontStyle.Italic)) {
+    val color = if (actor == CombatActor.ENEMY) colors.colorPurple else colors.color7A
+    withStyle(SpanStyle(color = color, fontStyle = FontStyle.Italic)) {
         append(name)
     }
 }
 
 private fun AnnotatedStringBuilder.appendSkill(
     name: String,
+    actor: CombatActor,
     colors: KiwiColorsData,
 ) {
-    withStyle(SpanStyle(color = colors.color8A, fontStyle = FontStyle.Italic, fontWeight = FontWeight.Bold)) {
+    val color = if (actor == CombatActor.ENEMY) colors.colorR else colors.color8A
+    withStyle(SpanStyle(color = color, fontStyle = FontStyle.Italic, fontWeight = FontWeight.Bold)) {
         append(name)
     }
 }
+
+// Connective, narrative glue — everything that isn't an actor, skill or
+// status. Uses the regular button text colour so it reads as plain prose.
+private fun AnnotatedStringBuilder.appendNarrative(
+    text: String,
+    colors: KiwiColorsData,
+) {
+    withStyle(SpanStyle(color = colors.colorF)) {
+        append(text)
+    }
+}
+
+// Wall-clock time a turn was resolved, e.g. "18:05h", for the log separators.
+private fun formatLogTime(timestampMillis: Long): String =
+    SimpleDateFormat("HH:mm'h'", Locale.getDefault()).format(Date(timestampMillis))
 
 private fun AnnotatedStringBuilder.appendStatus(
     name: String?,
@@ -307,12 +345,18 @@ fun CombatLog_Preview() {
         val colors = LocalKiwiColors.current
         val entries =
             remember {
+                val firstTurnTime = System.currentTimeMillis()
+                val secondTurnTime = firstTurnTime + 3_600_000L
                 buildCombatLogEntries(
                     actions =
                         listOf(
-                            CombatTestFactory.skillUsedAction(skillName = "Smite"),
-                            CombatTestFactory.skillUsedAction(actor = CombatActor.ENEMY, skillName = "Insomnia"),
-                            CombatTestFactory.skillUsedAction(skillName = "Wind"),
+                            CombatTestFactory.skillUsedAction(skillName = "Smite", createdAt = firstTurnTime),
+                            CombatTestFactory.skillUsedAction(
+                                actor = CombatActor.ENEMY,
+                                skillName = "Insomnia",
+                                createdAt = secondTurnTime,
+                            ),
+                            CombatTestFactory.skillUsedAction(skillName = "Wind", createdAt = secondTurnTime),
                         ),
                     enemyName = "Procrastinogre",
                     combatStatus = CombatGeneralStatus.ONGOING,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatLogOverlay.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatLogOverlay.kt
@@ -1,0 +1,80 @@
+package com.bellako.kiwi.features.combat.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.bellako.kiwi.ui.Spacing
+import com.bellako.kiwi.ui.getResponsiveSizeWidth
+
+private const val OVERLAY_FADE_MS = 220
+private const val LOG_SLIDE_MS = 300
+private const val LOG_HEIGHT_FRACTION = 0.7f
+private const val LOG_SLIDE_DIVISOR = 2
+
+/**
+ * The combat log surfaced on top of a combat screen: a full-screen dim plus
+ * the log panel, with a coordinated open/close animation (the dim fades, the
+ * panel slides up and fades).
+ *
+ * Rendered at the root of each combat screen so the dim covers the whole
+ * screen — the navbar lives outside this content area, so it stays clear.
+ */
+@Composable
+fun CombatLogOverlay(
+    isOpen: Boolean,
+    entries: List<CombatLogEntry>,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier.fillMaxSize()) {
+        AnimatedVisibility(
+            visible = isOpen,
+            enter = fadeIn(tween(OVERLAY_FADE_MS)),
+            exit = fadeOut(tween(OVERLAY_FADE_MS)),
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            LogDimOverlay(
+                modifier = Modifier.fillMaxSize(),
+                onDismiss = onDismiss,
+            )
+        }
+
+        AnimatedVisibility(
+            visible = isOpen,
+            enter =
+                slideInVertically(tween(LOG_SLIDE_MS)) { it / LOG_SLIDE_DIVISOR } +
+                    fadeIn(tween(LOG_SLIDE_MS)),
+            exit =
+                slideOutVertically(tween(LOG_SLIDE_MS)) { it / LOG_SLIDE_DIVISOR } +
+                    fadeOut(tween(LOG_SLIDE_MS)),
+            modifier = Modifier.align(Alignment.Center),
+        ) {
+            CombatLog(
+                entries = entries,
+                modifier =
+                    Modifier
+                        .padding(horizontal = getResponsiveSizeWidth(Spacing.medium))
+                        .fillMaxHeight(LOG_HEIGHT_FRACTION)
+                        // Swallow taps on the panel so they don't dismiss it.
+                        .clickable(
+                            indication = null,
+                            interactionSource = remember { MutableInteractionSource() },
+                            onClick = {},
+                        ),
+            )
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatPlayerControls.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatPlayerControls.kt
@@ -60,6 +60,8 @@ internal fun PlayerControls(
 
             Kiwi_Spacer(Spacing.small)
 
+            // The health bar is never dimmed by the overlay — the player must
+            // be able to read their HP clearly, especially while taking damage.
             CombatHealthBar(
                 currentHp = userActor.stats.currentHp,
                 maxHp = userActor.stats.maxHp,
@@ -68,8 +70,7 @@ internal fun PlayerControls(
                 modifier =
                     Modifier
                         .align(Alignment.CenterHorizontally)
-                        .fillMaxWidth(PLAYER_HEALTH_BAR_WIDTH_FRACTION)
-                        .alpha(dimAlpha),
+                        .fillMaxWidth(PLAYER_HEALTH_BAR_WIDTH_FRACTION),
                 barRevealProgress = playerBarRevealProgress,
                 numbersAlpha = playerBarNumbersAlpha,
             )

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTimer.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTimer.kt
@@ -142,6 +142,6 @@ fun CombatTimer_Preview() {
 @Suppress("MagicNumber")
 fun CombatTimer_Urgent_Preview() {
     Kiwi_Theme {
-        CombatTimer(endsAt = System.currentTimeMillis() + SECONDS_PER_MINUTE * 12 * TIMER_TICK_MILLIS)
+        CombatTimer(endsAt = System.currentTimeMillis() + SECONDS_PER_MINUTE * 6 * TIMER_TICK_MILLIS)
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTimer.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTimer.kt
@@ -1,5 +1,10 @@
 package com.bellako.kiwi.features.combat.components
 
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -12,6 +17,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
@@ -30,6 +36,17 @@ private const val SECONDS_PER_MINUTE = 60L
 private const val SECONDS_PER_HOUR = 3600L
 private const val EMPTY_TIMER = "--:--:--"
 private val TIMER_RADIUS = 20.dp
+
+// Below this much time remaining the timer blinks with a red tint to signal urgency.
+private const val URGENT_THRESHOLD_MILLIS = 10L * SECONDS_PER_MINUTE * TIMER_TICK_MILLIS
+
+// Duration of a single half of the blink cycle (fade in / fade out).
+private const val BLINK_HALF_CYCLE_MILLIS = 550
+
+// How far the red tint pushes toward fully red at the peak of the blink. The
+// background tint is kept subtler than the text/border so the time stays legible.
+private const val BLINK_TEXT_MAX = 1f
+private const val BLINK_BG_MAX = 0.45f
 
 // How far the timer starts shifted up at [introProgress] = 0, in dp. Sized so
 // the whole timer panel sits hidden behind the health bar above it during the
@@ -57,12 +74,26 @@ fun CombatTimer(
         }
     }
 
-    val text =
-        if (endsAt == null) {
-            EMPTY_TIMER
-        } else {
-            formatRemaining((endsAt - now).coerceAtLeast(0L))
-        }
+    val remainingMillis = if (endsAt == null) null else (endsAt - now).coerceAtLeast(0L)
+    val text = if (remainingMillis == null) EMPTY_TIMER else formatRemaining(remainingMillis)
+    val isUrgent = remainingMillis != null && remainingMillis <= URGENT_THRESHOLD_MILLIS
+
+    val blink = rememberInfiniteTransition(label = "combatTimerBlink")
+    val blinkFraction by blink.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec =
+            infiniteRepeatable(
+                animation = tween(BLINK_HALF_CYCLE_MILLIS),
+                repeatMode = RepeatMode.Reverse,
+            ),
+        label = "combatTimerBlinkFraction",
+    )
+    val tint = if (isUrgent) blinkFraction else 0f
+
+    val textColor = lerp(colors.colorF, colors.colorR, tint * BLINK_TEXT_MAX)
+    val bgColor = lerp(colors.color2, colors.colorR1, tint * BLINK_BG_MAX)
+    val borderColor = lerp(colors.color5C, colors.colorR, tint * BLINK_TEXT_MAX)
 
     val hideOffsetPx = with(LocalDensity.current) { TIMER_INTRO_HIDE_OFFSET.toPx() }
     val translationY = -hideOffsetPx * (1f - introProgress.coerceIn(0f, 1f))
@@ -72,7 +103,7 @@ fun CombatTimer(
             modifier
                 .graphicsLayer { this.translationY = translationY }
                 .alpha(introProgress.coerceIn(0f, 1f))
-                .combatPanel(bgColor = colors.color2, borderColor = colors.color5C, radius = TIMER_RADIUS)
+                .combatPanel(bgColor = bgColor, borderColor = borderColor, radius = TIMER_RADIUS)
                 .padding(
                     horizontal = getResponsiveSizeWidth(Spacing.medium),
                     vertical = getResponsiveSizeHeight(Spacing.xSmall),
@@ -82,7 +113,7 @@ fun CombatTimer(
         Kiwi_Label3(
             KiwiTextArguments(
                 text = text,
-                color = colors.colorF,
+                color = textColor,
                 fontWeight = FontWeight.Bold,
             ),
         )
@@ -103,5 +134,14 @@ private fun formatRemaining(remainingMillis: Long): String {
 fun CombatTimer_Preview() {
     Kiwi_Theme {
         CombatTimer(endsAt = System.currentTimeMillis() + SECONDS_PER_HOUR * 7 * TIMER_TICK_MILLIS)
+    }
+}
+
+@Preview(name = "Urgent", widthDp = 392, heightDp = 80)
+@Composable
+@Suppress("MagicNumber")
+fun CombatTimer_Urgent_Preview() {
+    Kiwi_Theme {
+        CombatTimer(endsAt = System.currentTimeMillis() + SECONDS_PER_MINUTE * 12 * TIMER_TICK_MILLIS)
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
@@ -31,6 +31,7 @@ import com.bellako.kiwi.features.combat.data.CombatActionDomain
 import com.bellako.kiwi.features.combat.data.CombatActionType
 import com.bellako.kiwi.features.combat.data.CombatActor
 import com.bellako.kiwi.features.combat.data.SkillEffectResultType
+import com.bellako.kiwi.ui.KIWI_DISABLED_ALPHA
 import com.bellako.kiwi.ui.Kiwi_Theme
 import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
@@ -58,11 +59,17 @@ fun CombatTurnIndicator(
     modifier: Modifier = Modifier,
     glowColor: Color? = null,
     introAlpha: Float = 1f,
+    dimmed: Boolean = false,
 ) {
     val colors = LocalKiwiColors.current
     val rotation by animateFloatAsState(
         targetValue = if (isLogOpen) CHEVRON_OPEN_ROTATION else CHEVRON_CLOSED_ROTATION,
         label = "combat_turn_chevron",
+    )
+    // Dimmed along with the rest of the HUD while an overlay (e.g. a bark) is up.
+    val dimAlpha by animateFloatAsState(
+        targetValue = if (dimmed) KIWI_DISABLED_ALPHA else 1f,
+        label = "combat_turn_dim",
     )
     val blinkAlpha = rememberBlinkAlpha()
 
@@ -74,7 +81,7 @@ fun CombatTurnIndicator(
         modifier =
             modifier
                 .fillMaxWidth()
-                .alpha(introAlpha)
+                .alpha(introAlpha * dimAlpha)
                 .combatPanel(
                     bgColor = colors.color3A,
                     borderColor = colors.color5C,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
@@ -61,7 +61,7 @@ fun CombatTurnIndicator(
 ) {
     val colors = LocalKiwiColors.current
     val rotation by animateFloatAsState(
-        targetValue = if (isLogOpen) CHEVRON_CLOSED_ROTATION else CHEVRON_OPEN_ROTATION,
+        targetValue = if (isLogOpen) CHEVRON_OPEN_ROTATION else CHEVRON_CLOSED_ROTATION,
         label = "combat_turn_chevron",
     )
     val blinkAlpha = rememberBlinkAlpha()

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatTurnIndicator.kt
@@ -60,6 +60,8 @@ fun CombatTurnIndicator(
     glowColor: Color? = null,
     introAlpha: Float = 1f,
     dimmed: Boolean = false,
+    // When true the indicator gently pulses to signal the player can act.
+    isUserTurn: Boolean = false,
 ) {
     val colors = LocalKiwiColors.current
     val rotation by animateFloatAsState(
@@ -72,6 +74,7 @@ fun CombatTurnIndicator(
         label = "combat_turn_dim",
     )
     val blinkAlpha = rememberBlinkAlpha()
+    val turnPulseAlpha = rememberTurnPulseAlpha(active = isUserTurn && !dimmed)
 
     LaunchedEffect(message.text) {
         blinkAlpha.blink()
@@ -95,7 +98,7 @@ fun CombatTurnIndicator(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
-            modifier = Modifier.weight(1f).alpha(blinkAlpha.value),
+            modifier = Modifier.weight(1f).alpha(blinkAlpha.value * turnPulseAlpha),
             contentAlignment = Alignment.Center,
         ) {
             Kiwi_AnnotatedString_P2(
@@ -159,6 +162,7 @@ fun CombatTurnIndicator_Preview() {
             isLogOpen = false,
             onClick = {},
             modifier = Modifier.padding(Spacing.medium),
+            isUserTurn = true,
         )
     }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatVfx.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatVfx.kt
@@ -2,6 +2,7 @@ package com.bellako.kiwi.features.combat.components
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,11 +13,15 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.scale
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlin.math.hypot
 
 private const val PLAYER_SHAKE_CYCLES = 4
 private const val PLAYER_SHAKE_AMPLITUDE_PX = 28f
@@ -27,15 +32,27 @@ private const val PLAYER_FLASH_ALPHA = 0.15f
 private const val PLAYER_VIGNETTE_PEAK_ALPHA = 0.3f
 private const val PLAYER_VIGNETTE_RISE_MS = 120
 private const val PLAYER_VIGNETTE_FALL_MS = 500
-private const val DEATH_PAUSE_MS = 400L
+// The death sequence is driven by a 0..1 "eyelids closed" progress: a few
+// flutters, then a slow full close. 0 = eyes open, 1 = eyes fully shut (black).
+// Total run time gates the defeat-screen transition — see DEFEAT_TRANSITION_DELAY_MS.
+private const val DEATH_PAUSE_MS = 500L
 private const val DEATH_BLINK_CYCLES = 3
-private const val DEATH_BLINK_RISE_MS = 180
-private const val DEATH_BLINK_FALL_MS = 220
-private const val DEATH_BLINK_PEAK_ALPHA = 0.55f
-private const val DEATH_BLINK_TROUGH_ALPHA = 0.15f
-private const val DEATH_HOLD_RISE_MS = 200
-private const val DEATH_HOLD_ALPHA = 0.6f
-private const val DEATH_VIGNETTE_INNER_ALPHA_FACTOR = 0.4f
+private const val DEATH_BLINK_RISE_MS = 260
+private const val DEATH_BLINK_FALL_MS = 320
+// How far the eyelids drop on each pre-close flutter, and how far they reopen between flutters.
+private const val DEATH_BLINK_PEAK = 0.5f
+private const val DEATH_BLINK_TROUGH = 0.08f
+private const val DEATH_CLOSE_MS = 700
+
+// Shape of the clear "eye" opening: a wide horizontal ellipse, so its height is
+// a small fraction of its width.
+private const val DEATH_VIGNETTE_EYE_ASPECT = 0.4f
+// Fraction of the opening's radius spent fading from clear to solid black.
+private const val DEATH_VIGNETTE_FEATHER = 0.55f
+// Headroom so the screen is still fully clear when the close has only just begun.
+private const val DEATH_VIGNETTE_OPEN_HEADROOM = 1.08f
+// Slight overdraw so the squashed cover rect leaves no hairline gap at the edges.
+private const val DEATH_VIGNETTE_COVER_OVERDRAW = 1.05f
 
 internal class PlayerDamageVfx(
     val shakeOffsetX: Animatable<Float, *>,
@@ -87,20 +104,21 @@ internal fun rememberDeathSequenceVfx(
     isPlayerDefeated: Boolean,
     key: Any,
 ): Animatable<Float, *> {
-    val alpha = remember(key) { Animatable(0f) }
+    val closeProgress = remember(key) { Animatable(0f) }
     LaunchedEffect(isPlayerDefeated, key) {
         if (!isPlayerDefeated) {
-            alpha.snapTo(0f)
+            closeProgress.snapTo(0f)
             return@LaunchedEffect
         }
         delay(DEATH_PAUSE_MS)
+        // A few eyelid flutters, then the eyes shut for good.
         repeat(DEATH_BLINK_CYCLES) {
-            alpha.animateTo(DEATH_BLINK_PEAK_ALPHA, tween(DEATH_BLINK_RISE_MS))
-            alpha.animateTo(DEATH_BLINK_TROUGH_ALPHA, tween(DEATH_BLINK_FALL_MS))
+            closeProgress.animateTo(DEATH_BLINK_PEAK, tween(DEATH_BLINK_RISE_MS))
+            closeProgress.animateTo(DEATH_BLINK_TROUGH, tween(DEATH_BLINK_FALL_MS))
         }
-        alpha.animateTo(DEATH_HOLD_ALPHA, tween(DEATH_HOLD_RISE_MS))
+        closeProgress.animateTo(1f, tween(DEATH_CLOSE_MS))
     }
-    return alpha
+    return closeProgress
 }
 
 @Composable
@@ -131,21 +149,54 @@ internal fun PlayerDamageOverlays(vfx: PlayerDamageVfx) {
     }
 }
 
+/**
+ * Black "closing eyes" vignette for the death sequence. [closeProgress] runs
+ * 0 (eyes open, fully clear) to 1 (eyes shut, fully black); the clear opening
+ * is a horizontal ellipse that shrinks from outside in as it rises.
+ */
 @Composable
-internal fun DeathSequenceOverlay(alpha: Float) {
-    if (alpha <= 0f) return
-    Box(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .background(
-                    Brush.radialGradient(
-                        colors =
-                            listOf(
-                                Color.Red.copy(alpha = alpha * DEATH_VIGNETTE_INNER_ALPHA_FACTOR),
-                                Color.Red.copy(alpha = alpha),
-                            ),
+internal fun DeathSequenceOverlay(closeProgress: Float) {
+    val progress = closeProgress.coerceIn(0f, 1f)
+    if (progress <= 0f) return
+    Canvas(modifier = Modifier.fillMaxSize()) {
+        // Eyes fully shut: a solid black cover, with no sub-pixel opening left.
+        if (progress >= 1f) {
+            drawRect(Color.Black)
+            return@Canvas
+        }
+        val center = Offset(size.width / 2f, size.height / 2f)
+        // Distance to a screen corner in the vertically-squashed space the
+        // gradient is drawn in — the opening must clear this to leave the
+        // screen fully visible at the start of the close.
+        val cornerRadius =
+            hypot(size.width / 2f, size.height / 2f / DEATH_VIGNETTE_EYE_ASPECT)
+        val fullyOpenRadius =
+            cornerRadius / (1f - DEATH_VIGNETTE_FEATHER) * DEATH_VIGNETTE_OPEN_HEADROOM
+        val openRadius = (fullyOpenRadius * (1f - progress)).coerceAtLeast(1f)
+
+        val brush =
+            Brush.radialGradient(
+                colorStops =
+                    arrayOf(
+                        0f to Color.Transparent,
+                        (1f - DEATH_VIGNETTE_FEATHER) to Color.Transparent,
+                        1f to Color.Black,
                     ),
-                ),
-    )
+                center = center,
+                radius = openRadius,
+            )
+        // Squash the y-axis so the circular gradient reads as a wide,
+        // eye-shaped ellipse. The cover rect is scaled up by 1/aspect first so
+        // that, once squashed, it still spans the whole screen — leaving solid
+        // clamped black everywhere outside the elliptical opening.
+        val coverWidth = size.width * DEATH_VIGNETTE_COVER_OVERDRAW
+        val coverHeight = size.height / DEATH_VIGNETTE_EYE_ASPECT * DEATH_VIGNETTE_COVER_OVERDRAW
+        scale(scaleX = 1f, scaleY = DEATH_VIGNETTE_EYE_ASPECT, pivot = center) {
+            drawRect(
+                brush = brush,
+                topLeft = Offset(center.x - coverWidth / 2f, center.y - coverHeight / 2f),
+                size = Size(coverWidth, coverHeight),
+            )
+        }
+    }
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDTO.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDTO.kt
@@ -112,4 +112,7 @@ data class CombatTurnResultDTO(
     val onCompletedEvent: String,
     val onCompletedEntityId: Int,
     val bonusActionPending: Boolean = false,
+    // Jackson numeric timestamp: epoch seconds with a fractional sub-second
+    // part, e.g. 1779442908.578937396. Converted to epoch millis in the mapper.
+    val createdAt: Double? = null,
 )

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDataMapper.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDataMapper.kt
@@ -1,6 +1,7 @@
 package com.bellako.kiwi.features.combat.data
 
 private const val NO_COMPLETION_EVENT_SENTINEL = "_"
+private const val MILLIS_PER_SECOND = 1000.0
 
 object CombatDataMapper {
     fun toDomain(dto: CombatDTO): CombatDomain =
@@ -42,6 +43,7 @@ object CombatDataMapper {
             onCompletedEvent = if (hasEvent) dto.onCompletedEvent else null,
             onCompletedEntityId = if (hasEvent) dto.onCompletedEntityId else null,
             bonusActionPending = dto.bonusActionPending,
+            createdAt = dto.createdAt?.let { epochSecondsToMillis(it) },
         )
     }
 
@@ -155,6 +157,7 @@ object CombatDataMapper {
             onCompletedEvent = domain.onCompletedEvent ?: NO_COMPLETION_EVENT_SENTINEL,
             onCompletedEntityId = domain.onCompletedEntityId ?: 0,
             bonusActionPending = domain.bonusActionPending,
+            createdAt = domain.createdAt?.let { epochMillisToSeconds(it) },
         )
 
     fun toDTO(domain: CombatActorDomain): CombatActorDTO =
@@ -228,4 +231,11 @@ object CombatDataMapper {
             critic = domain.critic,
             appliedStatus = domain.appliedStatus?.let { toDTO(it) },
         )
+
+    // The backend serialises createdAt as a Jackson numeric timestamp — epoch
+    // seconds with a fractional sub-second part, e.g. 1779442908.578937396.
+    // Sub-millisecond precision is dropped; the combat log only needs minutes.
+    private fun epochSecondsToMillis(epochSeconds: Double): Long = (epochSeconds * MILLIS_PER_SECOND).toLong()
+
+    private fun epochMillisToSeconds(epochMillis: Long): Double = epochMillis / MILLIS_PER_SECOND
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDataMapper.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDataMapper.kt
@@ -3,6 +3,7 @@ package com.bellako.kiwi.features.combat.data
 private const val NO_COMPLETION_EVENT_SENTINEL = "_"
 private const val MILLIS_PER_SECOND = 1000.0
 
+@Suppress("TooManyFunctions")
 object CombatDataMapper {
     fun toDomain(dto: CombatDTO): CombatDomain =
         CombatDomain(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDomain.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/data/CombatDomain.kt
@@ -109,6 +109,13 @@ data class CombatActionDomain(
     val blockedSkills: List<Long>? = null,
     val skillName: String? = null,
     val skillEffectsResults: List<SkillEffectResultDomain> = emptyList(),
+    /**
+     * Wall-clock time (epoch millis) the owning turn was resolved by the
+     * backend, copied from [CombatTurnResultDomain.createdAt] as the turn's
+     * actions are merged into the log. Null for actions loaded with a combat's
+     * initial log. Drives the timestamp separators in the combat log.
+     */
+    val createdAt: Long? = null,
 )
 
 @Serializable
@@ -154,4 +161,6 @@ data class CombatTurnResultDomain(
      * extra user turns (e.g. Inner Focus).
      */
     val bonusActionPending: Boolean = false,
+    /** Wall-clock time (epoch millis) the backend resolved this turn. */
+    val createdAt: Long? = null,
 )

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/model/CombatViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/model/CombatViewModel.kt
@@ -236,7 +236,7 @@ class CombatViewModel
                 current.copy(
                     turnNumber = result.turnNumber,
                     combatStatus = result.combatStatus,
-                    log = current.log + result.actions,
+                    log = current.log + result.actions.map { it.copy(createdAt = result.createdAt) },
                     onCompletedEvent = if (isTerminal) result.onCompletedEvent else null,
                     onCompletedEntityId = if (isTerminal) result.onCompletedEntityId else null,
                 )
@@ -261,6 +261,13 @@ class CombatViewModel
             ) {
                 val prev = state
                 state = applyActionEffects(state, actions.first())
+                // Stamp the optimistically-added player action (the last log
+                // entry) with the turn timestamp so it groups with the rest of
+                // the turn instead of opening a separate timestamp section.
+                state =
+                    state.copy(
+                        log = state.log.dropLast(1) + state.log.last().copy(createdAt = result.createdAt),
+                    )
                 _active.value = state
                 playActionSFX(actions.first())
                 playerSkillId?.let { barkController.onSkillUsed(CombatActor.USER, it) }
@@ -273,7 +280,7 @@ class CombatViewModel
             }
 
             for (i in startIndex until actions.size) {
-                val action = actions[i]
+                val action = actions[i].copy(createdAt = result.createdAt)
                 val prev = state
                 state = state.copy(log = state.log + action)
                 state = applyActionEffects(state, action)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatDefeatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatDefeatScreen.kt
@@ -3,11 +3,8 @@ package com.bellako.kiwi.features.combat.screens
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -40,7 +37,7 @@ import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.appbar.screens.AppBarScreen
-import com.bellako.kiwi.features.combat.components.CombatLog
+import com.bellako.kiwi.features.combat.components.CombatLogOverlay
 import com.bellako.kiwi.features.combat.components.buildCombatLogEntries
 import com.bellako.kiwi.features.combat.data.CombatActor
 import com.bellako.kiwi.features.combat.data.CombatDomain
@@ -61,7 +58,6 @@ private const val EDGE_FADE_TOP_ALPHA = 0.85f
 private const val EDGE_FADE_BOTTOM_ALPHA = 0.95f
 private const val EDGE_FADE_TOP_END = 0.18f
 private const val EDGE_FADE_BOTTOM_START = 0.55f
-private const val LOG_HEIGHT_FRACTION = 0.7f
 private val CONTINUE_BUTTON_HORIZONTAL_MARGIN = 56.dp
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -123,32 +119,6 @@ fun CombatDefeatScreen(
 
                     SkillsUsedList(skillsUsed = skillsUsed)
                 }
-
-                if (isLogOpen) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .background(Color.Black.copy(alpha = 0.55f))
-                                .clickable(
-                                    indication = null,
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    onClick = { isLogOpen = false },
-                                ),
-                    )
-                    CombatLog(
-                        entries = logEntries,
-                        modifier =
-                            Modifier
-                                .align(Alignment.Center)
-                                .fillMaxHeight(LOG_HEIGHT_FRACTION)
-                                .clickable(
-                                    indication = null,
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    onClick = {},
-                                ),
-                    )
-                }
             }
 
             Kiwi_Spacer(Spacing.medium)
@@ -170,6 +140,12 @@ fun CombatDefeatScreen(
 
             Kiwi_Spacer(Spacing.large)
         }
+
+        CombatLogOverlay(
+            isOpen = isLogOpen,
+            entries = logEntries,
+            onDismiss = { isLogOpen = false },
+        )
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatFlowScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatFlowScreen.kt
@@ -3,15 +3,19 @@ package com.bellako.kiwi.features.combat.screens
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.EaseInOut
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
@@ -23,10 +27,13 @@ import com.bellako.kiwi.features.combat.data.CombatGeneralStatus
 import com.bellako.kiwi.features.skills.data.SkillDomain
 import kotlinx.coroutines.delay
 
-private const val DEFEAT_TRANSITION_DELAY_MS = 1800L
-private const val DEFEAT_FADE_MS = 600
+// Held off until the death "closing eyes" sequence has fully blacked out the
+// screen (see CombatVfx death timing, ~2940ms), plus a margin so the combat
+// screen stays solid black for the whole crossfade and never peeks through.
+private const val DEFEAT_TRANSITION_DELAY_MS = 3200L
 private const val VICTORY_TRANSITION_DELAY_MS = 1200L
 private const val VICTORY_FADE_MS = 600
+private const val DEFEAT_REVEAL_FADE_MS = 900
 
 private enum class CombatPhase { COMBAT, VICTORY, DEFEAT }
 
@@ -77,40 +84,42 @@ fun CombatFlowScreen(
             }
         }
 
-        val fadeDuration =
-            when (phase.value) {
-                CombatPhase.VICTORY -> VICTORY_FADE_MS
-                else -> DEFEAT_FADE_MS
-            }
-        Crossfade(
-            targetState = phase.value,
-            animationSpec = tween(fadeDuration, easing = EaseInOut),
-            label = "combat_phase",
-        ) { current ->
-            when (current) {
-                CombatPhase.DEFEAT ->
-                    CombatDefeatScreen(
-                        combat = combat,
-                        deckSkills = deckSkills,
-                        onContinue = onDismiss,
-                    )
-                CombatPhase.VICTORY ->
-                    CombatVictoryScreen(
-                        combat = combat,
-                        deckSkills = deckSkills,
-                        onContinue = onVictoryContinue,
-                    )
-                CombatPhase.COMBAT ->
-                    CombatScreen(
-                        combat = combat,
-                        deckSkills = deckSkills,
-                        isTurnPlaying = isTurnPlaying,
-                        activeBark = activeBark,
-                        onBarkDismiss = onBarkDismiss,
-                        onConfirmAbandon = onConfirmAbandon,
-                        onSkillClick = onSkillClick,
-                        onApplyGoalProgress = onApplyGoalProgress,
-                    )
+        // The defeat screen is revealed from black: the death "closing eyes"
+        // sequence has already blacked out the combat screen, so the defeat
+        // screen cuts in behind a full black veil that then fades away. A
+        // crossfade here would instead re-reveal the combat screen underneath.
+        if (phase.value == CombatPhase.DEFEAT) {
+            CombatDefeatScreen(
+                combat = combat,
+                deckSkills = deckSkills,
+                onContinue = onDismiss,
+            )
+            DefeatRevealVeil()
+        } else {
+            Crossfade(
+                targetState = phase.value,
+                animationSpec = tween(VICTORY_FADE_MS, easing = EaseInOut),
+                label = "combat_phase",
+            ) { current ->
+                when (current) {
+                    CombatPhase.VICTORY ->
+                        CombatVictoryScreen(
+                            combat = combat,
+                            deckSkills = deckSkills,
+                            onContinue = onVictoryContinue,
+                        )
+                    CombatPhase.COMBAT, CombatPhase.DEFEAT ->
+                        CombatScreen(
+                            combat = combat,
+                            deckSkills = deckSkills,
+                            isTurnPlaying = isTurnPlaying,
+                            activeBark = activeBark,
+                            onBarkDismiss = onBarkDismiss,
+                            onConfirmAbandon = onConfirmAbandon,
+                            onSkillClick = onSkillClick,
+                            onApplyGoalProgress = onApplyGoalProgress,
+                        )
+                }
             }
         }
     }
@@ -121,3 +130,22 @@ private fun isCombatDefeat(combat: CombatDomain): Boolean =
         combat.log.none { it.actionType == CombatActionType.ABANDON }
 
 private fun isCombatVictory(combat: CombatDomain): Boolean = combat.combatStatus == CombatGeneralStatus.USER_WON
+
+// Black veil that hands the death-sequence blackout over to the defeat screen:
+// it starts fully opaque (matching the closed-eyes overlay) and fades out so
+// the defeat screen is revealed from black instead of cutting in.
+@Composable
+private fun DefeatRevealVeil() {
+    val alpha = remember { Animatable(1f) }
+    LaunchedEffect(Unit) {
+        alpha.animateTo(0f, tween(DEFEAT_REVEAL_FADE_MS, easing = EaseInOut))
+    }
+    if (alpha.value > 0f) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = alpha.value)),
+        )
+    }
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatResultsCommon.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatResultsCommon.kt
@@ -1,5 +1,6 @@
 package com.bellako.kiwi.features.combat.screens
 
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -21,11 +22,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_H3
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
@@ -43,6 +47,9 @@ import com.bellako.kiwi.ui.getResponsiveSizeWidth
 private val SKILL_CARD_RADIUS = 14.dp
 private val SKILL_ICON_SIZE = 36.dp
 private val LOG_TOGGLE_RADIUS = 10.dp
+private val CHEVRON_SIZE = 14.dp
+private const val CHEVRON_OPEN_ROTATION = 180f
+private const val CHEVRON_CLOSED_ROTATION = 0f
 
 internal data class SkillUsedSummary(
     val name: String,
@@ -85,6 +92,10 @@ internal fun SkillsUsedHeader(
     onToggleLog: () -> Unit,
 ) {
     val colors = LocalKiwiColors.current
+    val chevronRotation by animateFloatAsState(
+        targetValue = if (isLogOpen) CHEVRON_OPEN_ROTATION else CHEVRON_CLOSED_ROTATION,
+        label = "skills_log_chevron",
+    )
     Row(
         modifier = Modifier.fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
@@ -97,7 +108,7 @@ internal fun SkillsUsedHeader(
             ),
         )
         Box(modifier = Modifier.weight(1f))
-        Box(
+        Row(
             modifier =
                 Modifier
                     .background(
@@ -112,6 +123,7 @@ internal fun SkillsUsedHeader(
                         horizontal = getResponsiveSizeWidth(Spacing.medium),
                         vertical = getResponsiveSizeHeight(Spacing.small),
                     ),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Kiwi_Label2(
                 KiwiTextArguments(
@@ -119,6 +131,15 @@ internal fun SkillsUsedHeader(
                     color = colors.color7A,
                     italic = true,
                 ),
+            )
+            Spacer(modifier = Modifier.size(getResponsiveSizeWidth(Spacing.xSmall)))
+            Kiwi_Image(
+                painterResourceId = R.drawable.ic_dialogue_arrow,
+                alt = if (isLogOpen) "Close combat log" else "Open combat log",
+                modifier =
+                    Modifier
+                        .size(getResponsiveSizeHeight(CHEVRON_SIZE))
+                        .rotate(chevronRotation),
             )
         }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -107,6 +107,8 @@ fun CombatScreen(
 
     val enemyName = combat.enemyName.ifBlank { DEFAULT_ENEMY_NAME }
     val turnMessage = currentTurnMessage(combat, enemyName)
+    // The player can act when combat is live and no turn animation is mid-flight.
+    val isUserTurn = combat.combatStatus == CombatGeneralStatus.ONGOING && !isTurnPlaying
     val logEntries =
         remember(combat.log, combat.combatStatus, enemyName, colors) {
             buildCombatLogEntries(
@@ -174,6 +176,7 @@ fun CombatScreen(
                     combat = combat,
                     deckSkills = deckSkills,
                     turnMessage = turnMessage,
+                    isUserTurn = isUserTurn,
                     isLogOpen = isLogOpen,
                     isOverlayOpen = isOverlayOpen,
                     selectedStatus = selectedStatus,
@@ -235,6 +238,7 @@ private fun CombatBottomPanel(
     combat: CombatDomain,
     deckSkills: List<SkillDomain>,
     turnMessage: AnnotatedString,
+    isUserTurn: Boolean,
     isLogOpen: Boolean,
     isOverlayOpen: Boolean,
     selectedStatus: CombatActiveStatusDomain?,
@@ -268,6 +272,7 @@ private fun CombatBottomPanel(
             glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
             introAlpha = intro.turnIndicatorAlpha,
             dimmed = isOverlayOpen,
+            isUserTurn = isUserTurn,
         )
 
         Kiwi_Spacer(Spacing.medium)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -140,13 +140,14 @@ fun CombatScreen(
                 .fillMaxSize()
                 .background(colors.color2),
     ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .graphicsLayer { translationX = playerVfx.shakeOffsetX.value },
-        ) {
-            CombatBackground(combat.background, alpha = intro.backgroundAlpha)
+        Box(modifier = Modifier.fillMaxSize()) {
+            // Only the background shakes on player damage — the enemy sprite and
+            // the HUD stay put so it doesn't read as a full-camera shake.
+            CombatBackground(
+                background = combat.background,
+                alpha = intro.backgroundAlpha,
+                shakeOffsetX = { playerVfx.shakeOffsetX.value },
+            )
 
             CombatEnemySprite(
                 enemySprite = combat.enemySprite,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -77,7 +77,7 @@ private const val BOTTOM_PANEL_GRADIENT_START = -0.2f
 private const val BOTTOM_PANEL_GRADIENT_MID = 0.5f
 private const val BOTTOM_PANEL_GRADIENT_END = 1f
 private const val BARK_FADE_MS = 250
-private const val BARK_VERTICAL_BIAS = 0.15f
+private const val BARK_VERTICAL_BIAS = 0.25f
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -267,6 +267,7 @@ private fun CombatBottomPanel(
             onClick = onToggleLog,
             glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
             introAlpha = intro.turnIndicatorAlpha,
+            dimmed = isOverlayOpen,
         )
 
         Kiwi_Spacer(Spacing.medium)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -42,7 +42,7 @@ import com.bellako.kiwi.features.combat.components.CombatEnemySprite
 import com.bellako.kiwi.features.combat.components.CombatHeader
 import com.bellako.kiwi.features.combat.components.CombatTurnIndicator
 import com.bellako.kiwi.features.combat.components.DeathSequenceOverlay
-import com.bellako.kiwi.features.combat.components.LogDimOverlay
+import com.bellako.kiwi.features.combat.components.CombatLogOverlay
 import com.bellako.kiwi.features.combat.components.CombatIntroController
 import com.bellako.kiwi.features.combat.components.PlayerControls
 import com.bellako.kiwi.features.combat.components.PlayerDamageOverlays
@@ -157,24 +157,13 @@ fun CombatScreen(
             )
 
             Column(modifier = Modifier.fillMaxSize().padding(top = Spacing.large)) {
-                Box {
-                    CombatHeader(
-                        title = "Ongoing Combat",
-                        onClose = { showAbandonConfirm = true },
-                    )
-                    if (isLogOpen) {
-                        LogDimOverlay(
-                            modifier = Modifier.matchParentSize(),
-                            onDismiss = { isLogOpen = false },
-                        )
-                    }
-                }
+                CombatHeader(
+                    title = "Ongoing Combat",
+                    onClose = { showAbandonConfirm = true },
+                )
 
                 CombatBattleArea(
                     combat = combat,
-                    isLogOpen = isLogOpen,
-                    onDismissLog = { isLogOpen = false },
-                    logEntries = logEntries,
                     enemyBarRevealProgress = intro.enemyHealthMaskProgress,
                     enemyBarNumbersAlpha = intro.enemyHealthNumbersAlpha,
                     timerIntroProgress = intro.timerSlideProgress,
@@ -189,7 +178,6 @@ fun CombatScreen(
                     selectedStatus = selectedStatus,
                     intro = intro,
                     onToggleLog = { isLogOpen = !isLogOpen },
-                    onCloseLog = { isLogOpen = false },
                     onSkillClick = onSkillClick,
                     onApplyGoalProgress = onApplyGoalProgress,
                     onStatusClick = { status ->
@@ -220,6 +208,12 @@ fun CombatScreen(
 
         PlayerDamageOverlays(playerVfx)
         DeathSequenceOverlay(deathVignetteAlpha.value)
+
+        CombatLogOverlay(
+            isOpen = isLogOpen,
+            entries = logEntries,
+            onDismiss = { isLogOpen = false },
+        )
     }
 
     if (showAbandonConfirm) {
@@ -245,63 +239,53 @@ private fun CombatBottomPanel(
     selectedStatus: CombatActiveStatusDomain?,
     intro: CombatIntroController,
     onToggleLog: () -> Unit,
-    onCloseLog: () -> Unit,
     onSkillClick: (skillId: Long, skillName: String) -> Unit,
     onApplyGoalProgress: (skillId: Long, goalId: Long, newProgress: Int) -> Unit,
     onStatusClick: (CombatActiveStatusDomain) -> Unit,
     onDismissPopup: () -> Unit,
 ) {
     val colors = LocalKiwiColors.current
-    Box {
-        Column(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .background(
-                        Brush.verticalGradient(
-                            BOTTOM_PANEL_GRADIENT_START to Color.Transparent,
-                            BOTTOM_PANEL_GRADIENT_MID to colors.color2,
-                            BOTTOM_PANEL_GRADIENT_END to colors.color2,
-                        ),
-                    ).padding(
-                        horizontal = getResponsiveSizeWidth(Spacing.medium),
-                        vertical = getResponsiveSizeHeight(Spacing.small),
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .background(
+                    Brush.verticalGradient(
+                        BOTTOM_PANEL_GRADIENT_START to Color.Transparent,
+                        BOTTOM_PANEL_GRADIENT_MID to colors.color2,
+                        BOTTOM_PANEL_GRADIENT_END to colors.color2,
                     ),
-        ) {
-            CombatTurnIndicator(
-                message = turnMessage,
-                isLogOpen = isLogOpen,
-                onClick = onToggleLog,
-                glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
-                introAlpha = intro.turnIndicatorAlpha,
-            )
+                ).padding(
+                    horizontal = getResponsiveSizeWidth(Spacing.medium),
+                    vertical = getResponsiveSizeHeight(Spacing.small),
+                ),
+    ) {
+        CombatTurnIndicator(
+            message = turnMessage,
+            isLogOpen = isLogOpen,
+            onClick = onToggleLog,
+            glowColor = combatTurnGlowColor(combat.log.lastOrNull()),
+            introAlpha = intro.turnIndicatorAlpha,
+        )
 
-            Kiwi_Spacer(Spacing.medium)
+        Kiwi_Spacer(Spacing.medium)
 
-            PlayerControls(
-                deckSkills = deckSkills,
-                userActor = combat.user,
-                isOverlayOpen = isOverlayOpen,
-                selectedStatus = selectedStatus,
-                onSkillClick = onSkillClick,
-                onApplyGoalProgress = onApplyGoalProgress,
-                onStatusClick = onStatusClick,
-                onDismissPopup = onDismissPopup,
-                skillSlotIntroScale = { slotIndex -> intro.skillSlotScale(slotIndex) },
-                skillSlotIntroAlpha = { slotIndex -> intro.skillSlotAlpha(slotIndex) },
-                playerBarRevealProgress = intro.playerHealthMaskProgress,
-                playerBarNumbersAlpha = intro.playerHealthNumbersAlpha,
-            )
+        PlayerControls(
+            deckSkills = deckSkills,
+            userActor = combat.user,
+            isOverlayOpen = isOverlayOpen,
+            selectedStatus = selectedStatus,
+            onSkillClick = onSkillClick,
+            onApplyGoalProgress = onApplyGoalProgress,
+            onStatusClick = onStatusClick,
+            onDismissPopup = onDismissPopup,
+            skillSlotIntroScale = { slotIndex -> intro.skillSlotScale(slotIndex) },
+            skillSlotIntroAlpha = { slotIndex -> intro.skillSlotAlpha(slotIndex) },
+            playerBarRevealProgress = intro.playerHealthMaskProgress,
+            playerBarNumbersAlpha = intro.playerHealthNumbersAlpha,
+        )
 
-            Kiwi_Spacer(Spacing.large)
-        }
-
-        if (isLogOpen) {
-            LogDimOverlay(
-                modifier = Modifier.matchParentSize(),
-                onDismiss = onCloseLog,
-            )
-        }
+        Kiwi_Spacer(Spacing.large)
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatScreen.kt
@@ -120,7 +120,7 @@ fun CombatScreen(
         }
 
     val playerVfx = rememberPlayerDamageVfx(combat.user.stats.currentHp, combat.id)
-    val deathVignetteAlpha = rememberDeathSequenceVfx(combat.user.stats.currentHp == 0, combat.id)
+    val deathCloseProgress = rememberDeathSequenceVfx(combat.user.stats.currentHp == 0, combat.id)
     val nodeEntry = LocalNodeEntryTransition.current
     val nodeEntryScope = rememberCoroutineScope()
     LaunchedEffect(Unit) {
@@ -211,7 +211,7 @@ fun CombatScreen(
         }
 
         PlayerDamageOverlays(playerVfx)
-        DeathSequenceOverlay(deathVignetteAlpha.value)
+        DeathSequenceOverlay(deathCloseProgress.value)
 
         CombatLogOverlay(
             isOpen = isLogOpen,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatVictoryScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/screens/CombatVictoryScreen.kt
@@ -3,11 +3,8 @@ package com.bellako.kiwi.features.combat.screens
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -38,7 +35,7 @@ import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.appbar.screens.AppBarScreen
-import com.bellako.kiwi.features.combat.components.CombatLog
+import com.bellako.kiwi.features.combat.components.CombatLogOverlay
 import com.bellako.kiwi.features.combat.components.buildCombatLogEntries
 import com.bellako.kiwi.features.combat.data.CombatActor
 import com.bellako.kiwi.features.combat.data.CombatDomain
@@ -58,7 +55,6 @@ private const val EDGE_FADE_TOP_ALPHA = 0.85f
 private const val EDGE_FADE_BOTTOM_ALPHA = 0.95f
 private const val EDGE_FADE_TOP_END = 0.18f
 private const val EDGE_FADE_BOTTOM_START = 0.55f
-private const val LOG_HEIGHT_FRACTION = 0.7f
 private val CONTINUE_BUTTON_HORIZONTAL_MARGIN = 56.dp
 
 @RequiresApi(Build.VERSION_CODES.O)
@@ -120,32 +116,6 @@ fun CombatVictoryScreen(
 
                     SkillsUsedList(skillsUsed = skillsUsed)
                 }
-
-                if (isLogOpen) {
-                    Box(
-                        modifier =
-                            Modifier
-                                .fillMaxSize()
-                                .background(Color.Black.copy(alpha = 0.55f))
-                                .clickable(
-                                    indication = null,
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    onClick = { isLogOpen = false },
-                                ),
-                    )
-                    CombatLog(
-                        entries = logEntries,
-                        modifier =
-                            Modifier
-                                .align(Alignment.Center)
-                                .fillMaxHeight(LOG_HEIGHT_FRACTION)
-                                .clickable(
-                                    indication = null,
-                                    interactionSource = remember { MutableInteractionSource() },
-                                    onClick = {},
-                                ),
-                    )
-                }
             }
 
             Kiwi_Spacer(Spacing.medium)
@@ -167,6 +137,12 @@ fun CombatVictoryScreen(
 
             Kiwi_Spacer(Spacing.large)
         }
+
+        CombatLogOverlay(
+            isOpen = isLogOpen,
+            entries = logEntries,
+            onDismiss = { isLogOpen = false },
+        )
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/tests/CombatTestFactory.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/tests/CombatTestFactory.kt
@@ -83,6 +83,7 @@ object CombatTestFactory {
         actor: CombatActor = CombatActor.USER,
         skillName: String = "Fireball",
         damage: Float = 25f,
+        createdAt: Long? = null,
     ): CombatActionDomain =
         CombatActionDomain(
             actor = actor,
@@ -97,6 +98,7 @@ object CombatTestFactory {
                         critic = false,
                     ),
                 ),
+            createdAt = createdAt,
         )
 
     fun timeoutAction(): CombatActionDomain =
@@ -115,6 +117,7 @@ object CombatTestFactory {
         combatId: Long = 1L,
         turnNumber: Int = 1,
         actions: List<CombatActionDomain> = listOf(skillUsedAction()),
+        createdAt: Long? = null,
     ): CombatTurnResultDomain =
         CombatTurnResultDomain(
             combatId = combatId,
@@ -123,6 +126,7 @@ object CombatTestFactory {
             combatStatus = CombatGeneralStatus.ONGOING,
             onCompletedEvent = null,
             onCompletedEntityId = null,
+            createdAt = createdAt,
         )
 
     fun userWonTurnResult(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -56,13 +56,13 @@ import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
+import com.bellako.kiwi.common.screens.components.rememberCharacterIdleModifier
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
 import com.bellako.kiwi.features.conversations.components.ConversationOption
 import com.bellako.kiwi.features.conversations.components.Kiwi_DialogueText
 import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
 import com.bellako.kiwi.features.conversations.components.TypewriterState
-import com.bellako.kiwi.features.conversations.components.rememberCharacterIdleModifier
 import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationOptionDomain

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
@@ -43,11 +43,11 @@ import com.bellako.kiwi.R
 import com.bellako.kiwi.audio.AudioManager
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer_Horizontal
+import com.bellako.kiwi.common.screens.components.rememberBreathingModifier
 import com.bellako.kiwi.common.utils.AssetResolver
 import com.bellako.kiwi.features.conversations.components.CharacterName
 import com.bellako.kiwi.features.conversations.components.Kiwi_DialogueText
 import com.bellako.kiwi.features.conversations.components.Kiwi_TypewriterText
-import com.bellako.kiwi.features.conversations.components.rememberBreathingModifier
 import com.bellako.kiwi.features.conversations.components.rememberTypewriter
 import com.bellako.kiwi.features.conversations.data.ConversationDomain
 import com.bellako.kiwi.features.conversations.data.ConversationType

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/LogInScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/LogInScreen.kt
@@ -2,14 +2,23 @@ package com.bellako.kiwi.features.users.screens
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.requiredWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -21,11 +30,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -36,11 +49,13 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withLink
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.bellako.kiwi.R
 import com.bellako.kiwi.common.data.ScreenRoutes
 import com.bellako.kiwi.common.data.UIState
+import com.bellako.kiwi.common.screens.LOGIN_LOADING_ANIM_DURATION_MS
 import com.bellako.kiwi.common.screens.components.KiwiAnnotatedStringArguments
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_AnnotatedString_P1
@@ -51,7 +66,6 @@ import com.bellako.kiwi.common.screens.components.Kiwi_InfoBox
 import com.bellako.kiwi.common.screens.components.Kiwi_InputField
 import com.bellako.kiwi.common.screens.components.Kiwi_Label2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
-import com.bellako.kiwi.common.screens.LOGIN_LOADING_ANIM_DURATION_MS
 import com.bellako.kiwi.common.screens.components.LoadingModal
 import com.bellako.kiwi.common.screens.modals.ErrorModalScreen
 import com.bellako.kiwi.features.personality.data.PersonalityState
@@ -71,6 +85,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+
+// Time for the background to scroll by one full image width — i.e. one
+// seamless loop. Slow enough to read as an ambient drift, not obvious motion.
+private const val LOGIN_SCROLL_PERIOD_MS = 64000
 
 @Composable
 fun LogInScreen(
@@ -105,16 +123,7 @@ fun LogInScreen(
                 })
             }
             else -> {
-                Kiwi_Image(
-                    R.drawable.login_bg,
-                    "Login Background",
-                    modifier =
-                        Modifier
-                            .fillMaxHeight(imgPercentage)
-                            .align(Alignment.TopStart),
-                    contentScale = ContentScale.FillHeight,
-                    alignment = Alignment.TopStart,
-                )
+                ScrollingLoginBackground(imgPercentage)
 
                 Box(
                     modifier =
@@ -149,6 +158,71 @@ fun LogInScreen(
             }
         }
     }
+}
+
+/**
+ * The login background, scrolling endlessly to the right. Two copies of the
+ * image are laid edge to edge and shifted together by exactly one image width
+ * per loop, so a fresh copy always slides in from the left to replace the one
+ * leaving on the right — making the seam invisible. The shift is read only
+ * inside [graphicsLayer], so it runs on the draw phase without recomposition.
+ */
+@Composable
+private fun BoxScope.ScrollingLoginBackground(imgPercentage: Float) {
+    val painter = painterResource(R.drawable.login_bg)
+
+    BoxWithConstraints(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .fillMaxHeight(imgPercentage)
+                .align(Alignment.TopStart)
+                .clipToBounds(),
+    ) {
+        // The image is scaled to fill the band's height, so its on-screen
+        // width follows from its aspect ratio — that width is one scroll loop.
+        val intrinsic = painter.intrinsicSize
+        val heightPx = with(LocalDensity.current) { maxHeight.toPx() }
+        val imageWidthPx = if (intrinsic.height > 0f) intrinsic.width * heightPx / intrinsic.height else 0f
+        val imageWidthDp = with(LocalDensity.current) { imageWidthPx.toDp() }
+
+        val transition = rememberInfiniteTransition(label = "login_scroll")
+        val progress by transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec =
+                infiniteRepeatable(
+                    animation = tween(LOGIN_SCROLL_PERIOD_MS, easing = LinearEasing),
+                    repeatMode = RepeatMode.Restart,
+                ),
+            label = "login_scroll_progress",
+        )
+
+        // Trailing copy sits one width to the left; leading copy starts on
+        // screen. Both slide right by `shift`; at shift == imageWidth the
+        // trailing copy lands exactly where the leading one began.
+        val shift = progress * imageWidthPx
+        LoginBackgroundImage(imageWidthDp, translationXPx = shift - imageWidthPx)
+        LoginBackgroundImage(imageWidthDp, translationXPx = shift)
+    }
+}
+
+@Composable
+private fun LoginBackgroundImage(
+    width: Dp,
+    translationXPx: Float,
+) {
+    Kiwi_Image(
+        R.drawable.login_bg,
+        "Login Background",
+        modifier =
+            Modifier
+                .requiredWidth(width)
+                .fillMaxHeight()
+                .graphicsLayer { translationX = translationXPx },
+        contentScale = ContentScale.FillHeight,
+        alignment = Alignment.TopStart,
+    )
 }
 
 @Composable

--- a/mobile/app/src/main/java/com/bellako/kiwi/ui/Color.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/ui/Color.kt
@@ -130,3 +130,6 @@ val KiwiColorR1 = Color(0xFF752723)
 
 @Suppress("MagicNumber")
 val KiwiColorOcean = Color(0xFF007DAD)
+
+@Suppress("MagicNumber")
+val KiwiColorPurple = Color(0xFF9B7EDE)

--- a/mobile/app/src/main/java/com/bellako/kiwi/ui/Theme.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/ui/Theme.kt
@@ -66,6 +66,7 @@ data class KiwiColorsData(
     val colorR: Color,
     val colorR1: Color,
     val colorOcean: Color,
+    val colorPurple: Color,
 )
 
 val KiwiColors =
@@ -113,6 +114,7 @@ val KiwiColors =
         colorR = KiwiColorR,
         colorR1 = KiwiColorR1,
         colorOcean = KiwiColorOcean,
+        colorPurple = KiwiColorPurple,
     )
 
 val LocalKiwiColors = staticCompositionLocalOf { KiwiColors }


### PR DESCRIPTION
## Summary

Polishes the combat experience end-to-end. On the backend, \`saveCombatActions\` now captures a single \`Instant\` for the whole turn (instead of calling \`Instant.now()\` per log entry) and returns it in \`CombatTurnResultDTO.createdAt\`. The mobile client propagates this timestamp to each \`CombatActionDomain\` so the combat log groups entries under wall-clock time separators ("18:05h") instead of turn numbers. Visual improvements include an enemy idle breathing animation, a gentle turn-indicator pulse when it is the player's turn, an urgent red blink on the timer below 10 minutes, a bark bubble fade-in, a new Canvas "closing eyes" death vignette, background-only screen shake via overscan+clip, a \`CombatLogOverlay\` component (extracted from three screens that each inlined the same overlay code, now with a coordinated slide+fade animation), and a continuously scrolling parallax background on the login screen.

## Changes

### Dialog & Bark System

- **Bark bubble fade-in**: every bark now fades in on appear, keyed on \`triggerId\` so back-to-back barks each replay the animation.
- **Combat log action text**: sentences restructured to "You have used X against Y"; enemy actor names styled with \`colorPurple\`, enemy skill names with \`colorR\`, connective prose with \`colorF\` via a new \`appendNarrative\` helper. Added \`USER_NAME_PLACEHOLDER_TARGET\` ("you") for the object-position case.
- **Log separators**: \`CombatLogEntry.TurnSeparator\` replaced by \`CombatLogEntry.TimeSeparator\` — displays formatted wall-clock time ("18:05h") instead of "Turn N".

### Game Logic / Other

- **Backend timestamp**: \`CombatLogService.saveCombatActions\` returns the captured \`Instant\`; \`CombatTurnResultMapper.toDTO\` accepts it as a parameter and sets \`CombatTurnResultDTO.createdAt\`. Timeout and abandon paths pass \`Instant.now()\` directly.
- **Mobile data layer**: \`CombatTurnResultDTO.createdAt\` (Jackson epoch-seconds \`Double\`) is converted to epoch millis in \`CombatDataMapper\`; the ViewModel stamps each \`CombatActionDomain\` in a turn result with that timestamp, including the optimistically-added player action.
- **\`CombatLogOverlay\`**: new component extracted from three screens (\`CombatScreen\`, \`CombatDefeatScreen\`, \`CombatVictoryScreen\`), providing a coordinated dim fade + panel slide-up+fade open/close animation. Log panel height reduced from 85 % to 70 % of screen height.
- **Background shake**: \`CombatBackground\` accepts a \`shakeOffsetX\` lambda and renders the image at 2× overscan inside \`clipToBounds\` + \`requiredSize\`, so only the background moves on player damage — the HUD and enemy sprite stay fixed.
- **Death sequence**: rewritten as a \`Canvas\` "closing eyes" elliptical vignette (\`closeProgress\` 0 = open, 1 = fully black) replacing the old red radial gradient. Flutter timings tightened; full close takes 700 ms. \`CombatFlowScreen\` defeat transition delay extended to 3 200 ms to cover the complete close; \`DefeatRevealVeil\` fades the defeat screen in from black (avoids a crossfade that would re-expose the combat screen).
- **Enemy idle animation**: \`rememberBreathingModifier\` applied to \`CombatEnemySprite\`.
- **Turn indicator**: \`rememberTurnPulseAlpha\` added for a gentle alpha pulse while it is the player's turn; \`dimmed\` param animates the indicator down while an overlay is open; chevron open/closed rotation corrected (was inverted). Chevron with animated rotation also added to \`SkillsUsedHeader\` on the results screens.
- **Timer urgency**: below 10 minutes remaining, the timer's text, border, and background lerp toward red with a 550 ms blink cycle via \`lerp\` on theme colors.
- **Login background**: static image replaced by \`ScrollingLoginBackground\` — two copies of \`login_bg\` scroll endlessly right over a 64-second seamless loop, driven by \`graphicsLayer\` to avoid recomposition.
- **Refactor**: \`IdleAnimation\`, \`rememberBreathingModifier\`, \`rememberFloatingModifier\`, and \`rememberCharacterIdleModifier\` moved from \`features/conversations/components\` to \`common/screens/components\`; import sites updated.

## Schema / Migration Notes

No schema changes.

## Testing

1. Start the backend against \`kiwi_db_dev\` and verify that \`POST /combat/{id}/turn\` responses include a \`createdAt\` field (epoch-seconds decimal).
2. Open an ongoing combat and verify:
   - Enemy sprite breathes with a slow idle animation.
   - When it is your turn the turn-indicator text pulses gently; the pulse stops while an overlay is open.
   - With less than 10 minutes on the timer the panel, border, and text blink red.
   - Taking damage shakes only the background image — the HUD elements stay fixed.
   - Bark bubbles fade in on appear; a second bark still plays the fade.
   - Opening the combat log shows a slide-up + fade animation; tapping the dim closes it; tapping the panel does not.
3. Complete or lose a combat and verify:
   - Defeat plays the "closing eyes" elliptical vignette, screen goes fully black, then the defeat screen fades in from black.
   - Victory screen fades in with a crossfade as before.
   - Both result screens open the log via the animated overlay; the toggle button chevron rotates on open/close.
4. Inspect the combat log entries and verify entries within the same turn share a timestamp separator showing "HH:MMh", and a new separator appears when the timestamp changes across turns.
5. Navigate to the login screen and verify the background image scrolls smoothly in a continuous loop with no visible seam.

## Related

None.