### PR TITLE
Fix goals

### DIFF
--- a/backend/src/main/java/com/kiwi/features/goals/controllers/GoalController.java
+++ b/backend/src/main/java/com/kiwi/features/goals/controllers/GoalController.java
@@ -108,5 +108,11 @@ public class GoalController {
         List<GoalDTO> definitions = goalService.getGoalDefinitions(authentication);
         return ResponseEntity.ok(definitions);
     }
+
+    @PostMapping("/app_usage/auto_review")
+    public ResponseEntity<List<UserGoalStatusDTO>> autoReviewAppUsageGoals(Authentication authentication) {
+        List<UserGoalStatusDTO> reviewed = goalService.autoReviewAppUsageGoals(authentication);
+        return ResponseEntity.ok(reviewed);
+    }
 }
 

--- a/backend/src/main/java/com/kiwi/features/goals/controllers/GoalService.java
+++ b/backend/src/main/java/com/kiwi/features/goals/controllers/GoalService.java
@@ -3,6 +3,8 @@ package com.kiwi.features.goals.controllers;
 import com.kiwi.features.goals.data.*;
 import com.kiwi.features.goals.exceptions.GoalNotFoundException;
 import com.kiwi.features.goals.exceptions.GoalUnauthorizedException;
+import com.kiwi.features.metrics.controllers.MetricsRepository;
+import com.kiwi.features.metrics.data.MetricsPersistence;
 import com.kiwi.features.users.data.AppUsageType;
 import com.kiwi.features.users.data.UsersPersistence;
 import com.kiwi.features.users.controllers.UsersRepository;
@@ -29,6 +31,7 @@ public class GoalService {
     private final UsersRepository usersRepository;
     private final UsersService usersService;
     private final UserAppUsageRepository userAppUsageRepository;
+    private final MetricsRepository metricsRepository;
 
     public GoalService(
             UserGoalStatusRepository userGoalStatusRepository,
@@ -36,13 +39,15 @@ public class GoalService {
             GoalRepository goalRepository,
             UsersRepository usersRepository,
             UsersService usersService,
-            UserAppUsageRepository userAppUsageRepository) {
+            UserAppUsageRepository userAppUsageRepository,
+            MetricsRepository metricsRepository) {
         this.userGoalStatusRepository = userGoalStatusRepository;
         this.userGoalProgressRepository = userGoalProgressRepository;
         this.goalRepository = goalRepository;
         this.usersRepository = usersRepository;
         this.usersService = usersService;
         this.userAppUsageRepository = userAppUsageRepository;
+        this.metricsRepository = metricsRepository;
     }
 
     private void updateUserGoalProgressAfterCompletion(UsersPersistence user, GoalPersistence goal) {
@@ -324,6 +329,67 @@ public class GoalService {
                 .stream()
                 .map(GoalDataMapper::toDTO)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Silently reviews all in-progress APP_USAGE goals from previous days.
+     * Compares the stored daily metrics against each goal's target_override and
+     * marks the goal COMPLETED (with points) or NOT_COMPLETED accordingly.
+     * No user interaction is required.
+     */
+    @Transactional
+    public List<UserGoalStatusDTO> autoReviewAppUsageGoals(Authentication authentication) {
+        UsersPersistence user = getUserFromAuthentication(authentication);
+        LocalDate today = LocalDate.now();
+
+        List<UserGoalStatusPersistence> pending =
+                userGoalStatusRepository.findByUserAndStatusAndDateBeforeAndGoal_CategoryOrderByDateDesc(
+                        user, GoalStatus.IN_PROGRESS, today, GoalCategory.APP_USAGE);
+
+        List<UserGoalStatusDTO> results = new ArrayList<>();
+
+        for (UserGoalStatusPersistence entry : pending) {
+            Optional<MetricsPersistence> metricsOpt =
+                    metricsRepository.findByUserAndDate(user, entry.getDate());
+
+            if (metricsOpt.isEmpty()) {
+                // No metrics stored for that day — skip, cannot evaluate
+                continue;
+            }
+
+            MetricsPersistence metrics = metricsOpt.get();
+            Integer targetOverride = entry.getTargetOverride();
+            if (targetOverride == null || targetOverride <= 0) {
+                continue;
+            }
+
+            long actualUsageMs;
+            boolean achieved;
+
+            if (entry.getGoal().getType() == GoalType.APP_USAGE_GOOD) {
+                actualUsageMs = (long) metrics.getCurrentGoodTimeSeconds() * 1000L;
+                achieved = actualUsageMs >= targetOverride;
+            } else if (entry.getGoal().getType() == GoalType.APP_USAGE_BAD) {
+                actualUsageMs = (long) metrics.getCurrentBadTimeSeconds() * 1000L;
+                achieved = actualUsageMs <= targetOverride;
+            } else {
+                continue;
+            }
+
+            if (achieved) {
+                usersService.addPointsToUser(user.getId(), entry.getGoal().getReward());
+                updateUserGoalProgressAfterCompletion(user, entry.getGoal());
+                entry.setStatus(GoalStatus.COMPLETED);
+                entry.setValue((int) (actualUsageMs / 1000));
+            } else {
+                updateUserGoalProgressAfterFailure(user, entry.getGoal());
+                entry.setStatus(GoalStatus.NOT_COMPLETED);
+            }
+
+            results.add(UserGoalStatusDataMapper.toDTO(userGoalStatusRepository.save(entry)));
+        }
+
+        return results;
     }
     // endregion
 }

--- a/backend/src/test/java/com/kiwi/goals/GoalServiceTests.java
+++ b/backend/src/test/java/com/kiwi/goals/GoalServiceTests.java
@@ -5,6 +5,7 @@ import com.kiwi.features.goals.controllers.UserGoalProgressRepository;
 import com.kiwi.features.goals.data.*;
 import com.kiwi.features.goals.exceptions.GoalNotFoundException;
 import com.kiwi.features.goals.exceptions.GoalUnauthorizedException;
+import com.kiwi.features.metrics.controllers.MetricsRepository;
 import com.kiwi.features.users.controllers.UserAppUsageRepository;
 import com.kiwi.features.users.controllers.UsersService;
 import com.kiwi.features.users.data.UsersPersistence;
@@ -28,6 +29,7 @@ public class GoalServiceTests {
     private UsersTestRepositoryInMemory usersRepository;
     private UserGoalProgressRepository userGoalProgressRepository;
     private UserAppUsageRepository userAppUsageRepository;
+    private MetricsRepository metricsRepository;
     private UsersService usersService;
     private GoalService goalService;
 
@@ -41,6 +43,7 @@ public class GoalServiceTests {
         usersRepository = new UsersTestRepositoryInMemory();
         userGoalProgressRepository = mock(UserGoalProgressRepository.class);
         userAppUsageRepository = mock(UserAppUsageRepository.class);
+        metricsRepository = mock(MetricsRepository.class);
         usersService = mock(UsersService.class);
         goalService = new GoalService(
             userGoalStatusRepository,
@@ -48,7 +51,8 @@ public class GoalServiceTests {
             goalDefinitionRepository,
             usersRepository,
             usersService,
-            userAppUsageRepository);
+            userAppUsageRepository,
+            metricsRepository);
 
         testUser = new UsersPersistence();
         testUser.setId(1L);

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsRepository.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsRepository.kt
@@ -79,5 +79,10 @@ class GoalsRepository(
             api.saveAppUsageBaseline(dto)
         }
 
+    suspend fun autoReviewAppUsageGoals(): Result<List<UserGoalStatusDTO>> =
+        runCatching {
+            api.autoReviewAppUsageGoals()
+        }
+
     // endregion
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
@@ -412,6 +412,9 @@ class GoalsViewModel
         override suspend fun checkAndNotifyGoals() {
             val today = dateToString(LocalDate.now())
 
+            // Silently auto-review yesterday's APP_USAGE goals before showing user-facing modals
+            autoReviewAppUsageGoals()
+
             val inProgressResult = getGoalsInProgress()
             val yesterdayGoals = inProgressResult.getOrNull()
 
@@ -485,5 +488,11 @@ class GoalsViewModel
                     avgBadDailyUsageMs = badAvgMs,
                 )
                 repository.saveAppUsageBaseline(dto).getOrThrow()
+            }
+
+        override suspend fun autoReviewAppUsageGoals(): Result<Unit> =
+            runCatching {
+                repository.autoReviewAppUsageGoals().getOrThrow()
+                Unit
             }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
@@ -434,6 +434,7 @@ class GoalsViewModel
             val goalDefinitions = goalDefinitionsResult.getOrNull()
 
             if (!goalDefinitions.isNullOrEmpty()) {
+                createGoalsFromDefinitions(goalDefinitions)
                 notifyNewGoals(goalDefinitions)
             }
         }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.sync.withLock
 import java.time.LocalDate
 
 @HiltViewModel
+@Suppress("TooManyFunctions")
 class GoalsViewModel
     @Inject
     constructor(

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/IGoalsAPI.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/IGoalsAPI.kt
@@ -66,4 +66,7 @@ interface IGoalsAPI {
     suspend fun saveAppUsageBaseline(
         @Body dto: UserAppUsageDTO,
     ): UserAppUsageDTO
+
+    @POST("api/user/goals/app_usage/auto_review")
+    suspend fun autoReviewAppUsageGoals(): List<UserGoalStatusDTO>
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/IGoalsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/IGoalsViewModel.kt
@@ -43,4 +43,6 @@ interface IGoalsViewModel {
         goodApps: List<String>,
         badApps: List<String>,
     ): Result<UserAppUsageDTO>
+
+    suspend fun autoReviewAppUsageGoals(): Result<Unit>
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/screens/GoalsModal.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/screens/GoalsModal.kt
@@ -168,10 +168,7 @@ fun GoalsModal(
                             .weight(buttonPercentage),
                     onClick = {
                         coroutineScope.launch {
-                            if (goalModalType == GoalNotificationType.NEW) {
-                                val goalDefinitions = goals.filterIsInstance<GoalDomain>()
-                                goalsViewModel.createGoalsFromDefinitions(goalDefinitions)
-                            } else {
+                            if (goalModalType == GoalNotificationType.YESTERDAY) {
                                 for (goal in goals) {
                                     if (goal is UserGoalStatusDomain) {
                                         if (goal.value == goal.target) {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/tests/GoalsFakeViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/tests/GoalsFakeViewModel.kt
@@ -194,4 +194,6 @@ class GoalsFakeViewModel(
         badApps: List<String>,
     ): Result<UserAppUsageDTO> =
         Result.success(UserAppUsageDTO(avgGoodDailyUsageMs = 0L, avgBadDailyUsageMs = 0L))
+
+    override suspend fun autoReviewAppUsageGoals(): Result<Unit> = Result.success(Unit)
 }

--- a/mobile/app/src/test/java/com/bellako/kiwi/GoalsViewModelTest.kt
+++ b/mobile/app/src/test/java/com/bellako/kiwi/GoalsViewModelTest.kt
@@ -138,6 +138,8 @@ class GoalsViewModelTest {
 
                     override suspend fun saveAppUsageBaseline(dto: UserAppUsageDTO): UserAppUsageDTO =
                         throw UnsupportedOperationException("Not needed in tests")
+
+                    override suspend fun autoReviewAppUsageGoals(): List<UserGoalStatusDTO> = emptyList()
                 },
             )
 


### PR DESCRIPTION
## Summary

Fixes two issues in the APP_USAGE goals flow. First, goals left IN_PROGRESS from previous days were never automatically evaluated — users had to manually review them. This PR adds a silent auto-review step (backed by a new backend endpoint) that runs when the app opens: it compares each past APP_USAGE goal's target against the stored daily metrics and marks it COMPLETED (awarding points) or NOT_COMPLETED. Second, new goals from definitions were only created in the database after the user tapped the accept button on the new-goals popup. Goals are now created as soon as they are detected during \`checkAndNotifyGoals()\`, so the popup becomes informational rather than a prerequisite for persistence.

## Changes

### Game Logic / Other

- **Backend — new endpoint** `POST /api/user/goals/app_usage/auto_review`: evaluates all IN_PROGRESS APP_USAGE goals dated before today for the authenticated user. Compares `currentGoodTimeSeconds` / `currentBadTimeSeconds` from `MetricsPersistence` against each goal's `targetOverride`; awards points and updates progress on success, records failure otherwise. Requires `MetricsRepository` (injected into `GoalService`).
- **Mobile — auto-review on open**: `GoalsViewModel.checkAndNotifyGoals()` now calls `autoReviewAppUsageGoals()` before fetching in-progress goals, so past APP_USAGE goals are resolved silently each session.
- **Mobile — decouple goal creation from modal**: `createGoalsFromDefinitions()` is called in `checkAndNotifyGoals()` as soon as new definitions are found, before `notifyNewGoals()`. The accept-button handler in `GoalsModal` no longer needs to create goals for the `NEW` modal type; it now only handles the `YESTERDAY` review flow.
- **Tests**: `GoalServiceTests` and `GoalsViewModelTest` updated to wire the new `MetricsRepository` dependency; `GoalsFakeViewModel` gains a no-op stub.

## Schema / Migration Notes

No schema changes. The new service method queries existing `user_goal_status` and `metrics` tables only.

## Testing

1. Ensure at least one APP_USAGE goal is IN_PROGRESS for a past date (or back-date a row in `user_goal_status` on `kiwi_db_dev`).
2. Open the app — the auto-review call fires silently. Confirm the goal row in `user_goal_status` transitions to `COMPLETED` or `NOT_COMPLETED` depending on the metrics stored for that date.
3. Trigger the new-goals popup (no active goals + definitions available). Confirm goal rows are created in `user_goal_status` before the user taps accept, and the popup still appears as expected.
4. Call `POST /api/user/goals/app_usage/auto_review` directly to verify the response lists the evaluated `UserGoalStatusDTO` entries.

## Related

None.