### PR TITLE
Improvement/polish high prio

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/LoginLoadingScreen.kt
@@ -101,8 +101,21 @@ fun LoginLoadingScreen(
 
     LaunchedEffect(visible) {
         if (visible) {
-            present = true
+            // Reset stale state from the previous cycle BEFORE flipping
+            // `present = true`. Because this coroutine runs between "visible
+            // became true" and the recomposition triggered by `present = true`,
+            // all writes here are visible on the very first frame the content
+            // is drawn. Without this, the first frame of the second (or third,
+            // …) show would render the previous cycle's *final* state for one
+            // frame before LaunchedEffect(present) below got a chance to snap
+            // things back to the pre-entrance position.
+            enterOffset.snapTo(1f)
+            exitOffset.snapTo(0f)
+            spriteVisible = false
+            dialogueVisible = false
+            entranceComplete = false
             dismissRequested = false
+            present = true
         } else {
             dismissRequested = true
         }
@@ -112,11 +125,6 @@ fun LoginLoadingScreen(
     // cannot cancel the entrance — it always plays in full.
     LaunchedEffect(present) {
         if (!present) return@LaunchedEffect
-        entranceComplete = false
-        spriteVisible = false
-        dialogueVisible = false
-        enterOffset.snapTo(1f)
-        exitOffset.snapTo(0f)
         enterOffset.animateTo(0f, tween(LOGIN_LOADING_ANIM_DURATION_MS, easing = EaseInOut))
         spriteVisible = true
         delay(ELEMENT_ENTER_MS.toLong())

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -212,6 +212,7 @@ private fun AppScreen(
     val isCombatVisible by combatViewModel.isVisible.collectAsState()
     val isCombatTurnPlaying by combatViewModel.isTurnPlaying.collectAsState()
     val activeBark by combatViewModel.activeBark.collectAsState()
+    val hasResolvedCombatOnStartup by combatViewModel.hasResolvedCombatOnStartup.collectAsState()
     val skillsState by skillsViewModel.state.collectAsState()
 
     val isTipVisible by tipsViewModel.isVisible.collectAsState()
@@ -233,6 +234,25 @@ private fun AppScreen(
         }
     }
 
+    // Curtain stays up not just until feature data settles, but until the
+    // combat-resume question has been answered — otherwise on a cold start
+    // with an active combat the curtain drops while the map is still showing
+    // and combat overlay/music are still racing to mount.
+    val isStartupSettled by remember {
+        derivedStateOf {
+            !anyFeatureLoading && hasResolvedCombatOnStartup
+        }
+    }
+
+    // Map music must NOT play while we're still figuring out whether to
+    // resume a combat. Once that's resolved: if combat is visible, combat
+    // music plays via CombatFlowScreen; otherwise map music starts here.
+    val shouldPlayMapMusic by remember {
+        derivedStateOf {
+            hasResolvedCombatOnStartup && !isCombatVisible
+        }
+    }
+
     // Raised by the auth / sign-up screens the instant a map-bound action
     // begins (manual log in, auto log in once stored credentials are found,
     // the app-selection Confirm) — never at app launch or during sign-up
@@ -244,10 +264,10 @@ private fun AppScreen(
         delay(INITIAL_LOADING_MIN_DISPLAY_MS)
         withTimeoutOrNull(INITIAL_LOADING_MAX_DISPLAY_MS) {
             while (true) {
-                snapshotFlow { anyFeatureLoading }.first { !it }
+                snapshotFlow { isStartupSettled }.first { it }
                 val resumed =
                     withTimeoutOrNull(INITIAL_LOADING_SETTLE_MS) {
-                        snapshotFlow { anyFeatureLoading }.first { it }
+                        snapshotFlow { isStartupSettled }.first { !it }
                     }
                 if (resumed == null) break
             }
@@ -325,6 +345,7 @@ private fun AppScreen(
                         goalsViewModel = goalsViewModel,
                         skillsViewModel = skillsViewModel,
                         isCombatActive = activeCombat != null,
+                        shouldPlayMapMusic = shouldPlayMapMusic,
                     )
 
                     AnimatedVisibility(
@@ -439,8 +460,11 @@ private fun AppScreen(
             },
         )
 
-        // Overlay global de notificaciones — único colector, siempre activo
-        if (!isLoginScreen && isLoginCompleted) {
+        // Overlay global de notificaciones — único colector, siempre activo.
+        // Suppressed while the loading curtain is up so a cold-start (combat
+        // resume or otherwise) doesn't surface a queue of pop-ups before the
+        // user has actually landed on a screen.
+        if (!isLoginScreen && isLoginCompleted && !showAppLoading) {
             NotificationOverlay(
                 notificationManager = notificationManager,
                 onGoalClick = { type, goals ->
@@ -559,6 +583,17 @@ private val NAVBAR_ORDER =
 
 private fun isMapRoute(route: String?): Boolean = route == ScreenRoutes.HOME
 
+// The apps screen is reused as a "change apps" settings sub-screen. When it is
+// reached from Settings (and popped back to it), we want the same rise-from-
+// bottom / slide-down feel as the map transitions, distinct from the plain
+// fade used during the sign-up flow.
+private fun isSettingsAppsTransition(
+    initial: String?,
+    target: String?,
+): Boolean =
+    (initial == ScreenRoutes.SETTINGS && target == ScreenRoutes.SIGNUP4_APPS) ||
+        (initial == ScreenRoutes.SIGNUP4_APPS && target == ScreenRoutes.SETTINGS)
+
 // Focus variants share their base screen's slot so deep links order correctly.
 private fun navIndex(route: String?): Int =
     when (route) {
@@ -580,6 +615,14 @@ private fun screenEnter(
     val from = navIndex(initial)
     val to = navIndex(target)
     return when {
+        // Settings → Change Apps rises from the bottom; popping back reveals
+        // Settings underneath instantly while the apps screen slides down.
+        isSettingsAppsTransition(initial, target) ->
+            if (target == ScreenRoutes.SIGNUP4_APPS) {
+                slideInVertically(animationSpec = screenOffsetSpec(MAP_TRANSITION_MS)) { it }
+            } else {
+                EnterTransition.None
+            }
         // Login / sign-up / any non-nav screen: keep a plain fade.
         from < 0 || to < 0 -> fadeIn(animationSpec = screenFadeSpec())
         // Going to the map: it is already rendered behind (this is a pop), so it
@@ -604,6 +647,14 @@ private fun screenExit(
     val from = navIndex(initial)
     val to = navIndex(target)
     return when {
+        // Settings → Change Apps: Settings holds still while the apps screen rises
+        // over it; on the way back the apps screen slides down to reveal Settings.
+        isSettingsAppsTransition(initial, target) ->
+            if (initial == ScreenRoutes.SIGNUP4_APPS) {
+                slideOutVertically(animationSpec = screenOffsetSpec(MAP_REVEAL_MS)) { it }
+            } else {
+                ExitTransition.None
+            }
         from < 0 || to < 0 -> fadeOut(animationSpec = screenFadeSpec())
         // Going to the map: the leaving screen slides straight down at full opacity,
         // slower so the reveal reads clearly.
@@ -632,6 +683,7 @@ fun AppNavHost(
     goalsViewModel: IGoalsViewModel,
     skillsViewModel: ISkillsViewModel,
     isCombatActive: Boolean = false,
+    shouldPlayMapMusic: Boolean = true,
 ) {
     NavHost(
         navController = navController,
@@ -699,7 +751,11 @@ fun AppNavHost(
 
         composable(ScreenRoutes.HOME) {
             AppScreenWrapper {
-                Kiwi_Music_Home()
+                // Gated so a cold-start combat resume doesn't flash map music
+                // before CombatFlowScreen takes over the audio.
+                if (shouldPlayMapMusic) {
+                    Kiwi_Music_Home()
+                }
                 MapScreen(
                     nodesViewModel = nodesViewModel,
                     goalsViewModel = goalsViewModel,

--- a/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/common/screens/MainScreen.kt
@@ -744,6 +744,7 @@ fun AppNavHost(
                     usersViewModel = usersViewModel,
                     personalityViewModel = personalityViewModel,
                     goalsViewModel = goalsViewModel,
+                    nodesViewModel = nodesViewModel,
                     navController = navController,
                 )
             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/model/CombatViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/model/CombatViewModel.kt
@@ -64,6 +64,14 @@ class CombatViewModel
         private val _isTurnPlaying = MutableStateFlow(false)
         val isTurnPlaying: StateFlow<Boolean> = _isTurnPlaying.asStateFlow()
 
+        // Flips true once tryResumeActive has finished its first run — whether
+        // or not it found a combat. MainScreen reads this to (a) keep the
+        // initial loading curtain up until the resume question is answered,
+        // and (b) suppress map music during that window, so a cold-start
+        // resume goes straight to combat music with no map-music flash.
+        private val _hasResolvedCombatOnStartup = MutableStateFlow(false)
+        val hasResolvedCombatOnStartup: StateFlow<Boolean> = _hasResolvedCombatOnStartup.asStateFlow()
+
         init {
             GlobalScope.launch(Dispatchers.Main) {
                 listenToEvent(EventType.START_COMBAT) { payload ->
@@ -104,7 +112,10 @@ class CombatViewModel
         }
 
         fun tryResumeActive() {
-            if (_active.value != null) return
+            if (_active.value != null) {
+                _hasResolvedCombatOnStartup.value = true
+                return
+            }
             viewModelScope.launch {
                 try {
                     val combat = repository.getActiveCombat() ?: return@launch
@@ -115,6 +126,11 @@ class CombatViewModel
                     barkController.onCombatStarted(combat)
                 } catch (e: Throwable) {
                     setUiState(mapExceptionToUIState(e))
+                } finally {
+                    // Flip AFTER _isVisible so any observer that reacts to the
+                    // flag (curtain wait, map-music gate) sees the combat
+                    // already in place when it unblocks.
+                    _hasResolvedCombatOnStartup.value = true
                 }
             }
         }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
@@ -154,33 +154,14 @@ fun MapScreen(
         loadNodes(mapViewModel, nodesViewModel, 0)
     }
 
-    // Fresh-account safety net: after a brand-new sign-up the user lands here
-    // with every node still INACCESSIBLE/LOCKED — all hidden under the mist —
-    // so the map reads as empty. Once the load settles, if no node has been
-    // touched yet, auto-unlock and auto-execute the first one so the opening
-    // beat fires and there is something on screen to engage with.
+    // Fresh-account safety net: after a brand-new sign-up the user can land
+    // here with every node still INACCESSIBLE/LOCKED — all hidden under the
+    // mist — so the map reads as empty. If no node has been touched yet, the
+    // helper auto-unlocks and auto-executes the first one so the opening beat
+    // fires. Sign-up normally drives this explicitly under the loading
+    // curtain; this catches the case where that round-trip failed.
     LaunchedEffect(Unit) {
-        val loaded = nodesViewModel.state.first { (it?.nodes?.isNotEmpty()) == true } ?: return@LaunchedEffect
-        val initialNodes = loaded.nodes.values.toList()
-        if (initialNodes.any { it.status == NodeStatus.OPEN || it.status == NodeStatus.COMPLETED }) {
-            return@LaunchedEffect
-        }
-
-        val firstNode = initialNodes.first()
-
-        nodesViewModel.unlockNode(firstNode.id)
-        nodesViewModel.state.first { it?.nodes?.get(firstNode.id)?.status == NodeStatus.OPEN }
-        mapViewModel.setPlayerNode(firstNode.id)
-
-        nodesViewModel.completeNode(firstNode.id)
-        nodesViewModel.state.first { it?.nodes?.get(firstNode.id)?.status == NodeStatus.COMPLETED }
-
-        if (firstNode.onExecutionEvent.isNotBlank() && firstNode.onExecutionEvent != "_") {
-            EventBus.emitEvent(
-                EventType.valueOf(firstNode.onExecutionEvent),
-                EventPayload.EntityIdPayload(firstNode.onExecutionEntityId),
-            )
-        }
+        runAutoExecuteFirstNodeIfNeeded(nodesViewModel, mapViewModel)
     }
 
     LaunchedEffect(Unit) {
@@ -398,6 +379,31 @@ private fun loadNodes(
                 }
             }
         }.launchIn(CoroutineScope(Dispatchers.Main))
+}
+
+private suspend fun runAutoExecuteFirstNodeIfNeeded(
+    nodesViewModel: INodesViewModel,
+    mapViewModel: MapViewModel,
+) {
+    val loaded = nodesViewModel.state.first { (it?.nodes?.isNotEmpty()) == true } ?: return
+    val initialNodes = loaded.nodes.values.toList()
+    if (initialNodes.any { it.status == NodeStatus.OPEN || it.status == NodeStatus.COMPLETED }) return
+
+    val firstNode = initialNodes.first()
+
+    nodesViewModel.unlockNode(firstNode.id)
+    nodesViewModel.state.first { it?.nodes?.get(firstNode.id)?.status == NodeStatus.OPEN }
+    mapViewModel.setPlayerNode(firstNode.id)
+
+    nodesViewModel.completeNode(firstNode.id)
+    nodesViewModel.state.first { it?.nodes?.get(firstNode.id)?.status == NodeStatus.COMPLETED }
+
+    if (firstNode.onExecutionEvent.isNotBlank() && firstNode.onExecutionEvent != "_") {
+        EventBus.emitEvent(
+            EventType.valueOf(firstNode.onExecutionEvent),
+            EventPayload.EntityIdPayload(firstNode.onExecutionEntityId),
+        )
+    }
 }
 
 @Suppress("LongMethod")

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/map/screens/MapScreen.kt
@@ -80,6 +80,7 @@ import com.bellako.kiwi.ui.getScreenWidth
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -151,6 +152,35 @@ fun MapScreen(
 
     LaunchedEffect(Unit) {
         loadNodes(mapViewModel, nodesViewModel, 0)
+    }
+
+    // Fresh-account safety net: after a brand-new sign-up the user lands here
+    // with every node still INACCESSIBLE/LOCKED — all hidden under the mist —
+    // so the map reads as empty. Once the load settles, if no node has been
+    // touched yet, auto-unlock and auto-execute the first one so the opening
+    // beat fires and there is something on screen to engage with.
+    LaunchedEffect(Unit) {
+        val loaded = nodesViewModel.state.first { (it?.nodes?.isNotEmpty()) == true } ?: return@LaunchedEffect
+        val initialNodes = loaded.nodes.values.toList()
+        if (initialNodes.any { it.status == NodeStatus.OPEN || it.status == NodeStatus.COMPLETED }) {
+            return@LaunchedEffect
+        }
+
+        val firstNode = initialNodes.first()
+
+        nodesViewModel.unlockNode(firstNode.id)
+        nodesViewModel.state.first { it?.nodes?.get(firstNode.id)?.status == NodeStatus.OPEN }
+        mapViewModel.setPlayerNode(firstNode.id)
+
+        nodesViewModel.completeNode(firstNode.id)
+        nodesViewModel.state.first { it?.nodes?.get(firstNode.id)?.status == NodeStatus.COMPLETED }
+
+        if (firstNode.onExecutionEvent.isNotBlank() && firstNode.onExecutionEvent != "_") {
+            EventBus.emitEvent(
+                EventType.valueOf(firstNode.onExecutionEvent),
+                EventPayload.EntityIdPayload(firstNode.onExecutionEntityId),
+            )
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/model/INodesViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/model/INodesViewModel.kt
@@ -1,6 +1,7 @@
 package com.bellako.kiwi.features.nodes.model
 
 import com.bellako.kiwi.common.model.IBaseViewModel
+import com.bellako.kiwi.features.nodes.data.NodesDomain
 import com.bellako.kiwi.features.nodes.data.NodesState
 
 interface INodesViewModel : IBaseViewModel<NodesState> {
@@ -9,4 +10,13 @@ interface INodesViewModel : IBaseViewModel<NodesState> {
     fun unlockNode(nodeId: Long)
 
     fun completeNode(nodeId: Long)
+
+    // Fresh-account hand-off: load the first map's nodes, and if the user has
+    // no progress yet (no OPEN/COMPLETED), unlock + complete the first node so
+    // the opening beat fires. Suspends until the round-trip is done, so the
+    // sign-up flow can call this under the loading curtain and only navigate
+    // to the map once the state is final. Returns the completed node (with
+    // its onExecutionEvent info) for the caller to emit, or null if no
+    // auto-execution was performed.
+    suspend fun autoExecuteFirstNode(mapId: Int): NodesDomain?
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/model/NodesViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/model/NodesViewModel.kt
@@ -9,6 +9,7 @@ import com.bellako.kiwi.common.services.eventbus.EventPayload
 import com.bellako.kiwi.common.services.eventbus.EventType
 import com.bellako.kiwi.common.services.eventbus.listenToEvent
 import com.bellako.kiwi.common.utils.Logger.warn
+import com.bellako.kiwi.features.nodes.data.NodeStatus
 import com.bellako.kiwi.features.nodes.data.NodesDomain
 import com.bellako.kiwi.features.nodes.data.NodesState
 import com.bellako.kiwi.features.users.model.UsersRepository
@@ -83,6 +84,41 @@ class NodesViewModel
 
             updateNodesSafe {
                 repository.completeNode(nodeId)
+            }
+        }
+
+        override suspend fun autoExecuteFirstNode(mapId: Int): NodesDomain? {
+            setIsLoading(true)
+            return try {
+                val nodes = repository.getNodesByMapId(mapId)
+                if (nodes.isEmpty()) return null
+
+                _state.value = NodesState(nodes = nodes.associateBy { it.id })
+
+                // Already has progress on this map — leave the user where they are.
+                if (nodes.any { it.status == NodeStatus.OPEN || it.status == NodeStatus.COMPLETED }) {
+                    return null
+                }
+
+                val firstNode = nodes.first()
+                val afterUnlock = repository.unlockNode(firstNode.id)
+                usersRepository.getMyUserPoints()
+                val afterComplete = repository.completeNode(firstNode.id)
+
+                val merged = _state.value.nodes.toMutableMap()
+                afterUnlock.forEach { merged[it.id] = it }
+                afterComplete.forEach { merged[it.id] = it }
+                _state.value = NodesState(nodes = merged)
+
+                merged[firstNode.id]
+            } catch (e: Exception) {
+                // Swallow on purpose: the sign-up flow needs to keep moving and
+                // land the user on the map regardless. If this fails, the map's
+                // own LaunchedEffect retries on next mount.
+                warn("autoExecuteFirstNode failed: ${e.message}")
+                null
+            } finally {
+                setIsLoading(false)
             }
         }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/model/NodesViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/model/NodesViewModel.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import retrofit2.HttpException
 import java.io.IOException
 import java.security.GeneralSecurityException
 import javax.inject.Inject
@@ -89,37 +90,47 @@ class NodesViewModel
 
         override suspend fun autoExecuteFirstNode(mapId: Int): NodesDomain? {
             setIsLoading(true)
+            // Swallow network failures on purpose: the sign-up flow needs to keep
+            // moving and land the user on the map regardless. If this fails, the
+            // map's own LaunchedEffect retries on next mount.
             return try {
                 val nodes = repository.getNodesByMapId(mapId)
-                if (nodes.isEmpty()) return null
-
-                _state.value = NodesState(nodes = nodes.associateBy { it.id })
-
-                // Already has progress on this map — leave the user where they are.
-                if (nodes.any { it.status == NodeStatus.OPEN || it.status == NodeStatus.COMPLETED }) {
-                    return null
+                when {
+                    nodes.isEmpty() -> null
+                    nodes.any { it.status == NodeStatus.OPEN || it.status == NodeStatus.COMPLETED } -> {
+                        _state.value = NodesState(nodes = nodes.associateBy { it.id })
+                        null
+                    }
+                    else -> performAutoExecuteFirstNode(nodes)
                 }
-
-                val firstNode = nodes.first()
-                val afterUnlock = repository.unlockNode(firstNode.id)
-                usersRepository.getMyUserPoints()
-                val afterComplete = repository.completeNode(firstNode.id)
-
-                val merged = _state.value.nodes.toMutableMap()
-                afterUnlock.forEach { merged[it.id] = it }
-                afterComplete.forEach { merged[it.id] = it }
-                _state.value = NodesState(nodes = merged)
-
-                merged[firstNode.id]
-            } catch (e: Exception) {
-                // Swallow on purpose: the sign-up flow needs to keep moving and
-                // land the user on the map regardless. If this fails, the map's
-                // own LaunchedEffect retries on next mount.
-                warn("autoExecuteFirstNode failed: ${e.message}")
+            } catch (e: HttpException) {
+                warn("autoExecuteFirstNode HTTP error: ${e.message}")
+                null
+            } catch (e: IOException) {
+                warn("autoExecuteFirstNode network error: ${e.message}")
+                null
+            } catch (e: GeneralSecurityException) {
+                warn("autoExecuteFirstNode encryption error: ${e.message}")
                 null
             } finally {
                 setIsLoading(false)
             }
+        }
+
+        private suspend fun performAutoExecuteFirstNode(nodes: List<NodesDomain>): NodesDomain? {
+            _state.value = NodesState(nodes = nodes.associateBy { it.id })
+
+            val firstNode = nodes.first()
+            val afterUnlock = repository.unlockNode(firstNode.id)
+            usersRepository.getMyUserPoints()
+            val afterComplete = repository.completeNode(firstNode.id)
+
+            val merged = _state.value.nodes.toMutableMap()
+            afterUnlock.forEach { merged[it.id] = it }
+            afterComplete.forEach { merged[it.id] = it }
+            _state.value = NodesState(nodes = merged)
+
+            return merged[firstNode.id]
         }
 
         // -----------------------------------------------------------------------------------------

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/tests/NodesFakeViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/tests/NodesFakeViewModel.kt
@@ -100,4 +100,8 @@ class NodesFakeViewModel(
         handleSuccess()
         setUiState(UIState.Success(Unit))
     }
+
+    // ---------------------------------------------------------------------------------------------
+
+    override suspend fun autoExecuteFirstNode(mapId: Int): NodesDomain? = null
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/skills/screen/SkillDetailsModal.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/skills/screen/SkillDetailsModal.kt
@@ -231,7 +231,7 @@ fun SkillDetails(
                                     goalProgress,
                                     skill.goalData.target,
                                     onProgressChange = { goalProgress = it },
-                                    enabled = !skill.isCooldown,
+                                    enabled = skill.isCooldown,
                                     kiwiColors,
                                 )
                             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen1_Welcome.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen1_Welcome.kt
@@ -116,7 +116,7 @@ private fun Welcome(
 }
 
 @Composable
-private fun GoToLogIn(onSignUp: () -> Unit) {
+internal fun GoToLogIn(onSignUp: () -> Unit) {
     val kiwiColors = LocalKiwiColors.current
     val annotatedString =
         buildAnnotatedString {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen2_Form.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen2_Form.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -71,6 +72,18 @@ fun SignUpScreen2_Form(
             personalityViewModel,
             navController,
         )
+
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(bottom = getResponsiveSizeHeight(Spacing.large)),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            GoToLogIn {
+                navController.navigate(ScreenRoutes.LOGIN)
+            }
+        }
     }
 }
 

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen4_Apps.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen4_Apps.kt
@@ -443,24 +443,35 @@ fun AppClassificationColumns(
             color = kiwiColors.color5A,
             onClick = {
                 CoroutineScope(Dispatchers.Main).launch {
-                    // App selection is the final sign-up step — raise the
-                    // map-entry loading curtain now so it covers the save and
-                    // the navigation into the map.
-                    usersViewModel.setShowAppLoading(true)
+                    // Settings re-uses this screen for "change apps". In that mode
+                    // we save and slide back down to Settings — no map-entry curtain,
+                    // no baseline reset (the baseline is fixed at signup).
+                    val fromSettings =
+                        navController.previousBackStackEntry?.destination?.route == ScreenRoutes.SETTINGS
+                    if (!fromSettings) {
+                        // App selection is the final sign-up step — raise the
+                        // map-entry loading curtain now so it covers the save and
+                        // the navigation into the map.
+                        usersViewModel.setShowAppLoading(true)
+                    }
                     personalityViewModel.onAppsChanged(
                         goodApps.map { it.packageName },
                         badApps.map { it.packageName },
                         neutralApps.map { it.packageName },
                     )
                     if (personalityViewModel.updateApps().isSuccess) {
-                        firebaseLogEvent(FirebaseEventNames.SIGNUP_4_APPS_COMPLETED)
-                        goalsViewModel.saveBaselineAppUsage(
-                            goodApps.map { it.packageName },
-                            badApps.map { it.packageName },
-                        )
-                        navController.navigate(ScreenRoutes.HOME)
-                        onUpdateSuccess()
-                    } else {
+                        if (fromSettings) {
+                            navController.popBackStack()
+                        } else {
+                            firebaseLogEvent(FirebaseEventNames.SIGNUP_4_APPS_COMPLETED)
+                            goalsViewModel.saveBaselineAppUsage(
+                                goodApps.map { it.packageName },
+                                badApps.map { it.packageName },
+                            )
+                            navController.navigate(ScreenRoutes.HOME)
+                            onUpdateSuccess()
+                        }
+                    } else if (!fromSettings) {
                         usersViewModel.setShowAppLoading(false)
                     }
                 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen4_Apps.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen4_Apps.kt
@@ -70,6 +70,11 @@ import com.bellako.kiwi.analytics.firebaseLogEvent
 import com.bellako.kiwi.common.data.ScreenRoutes
 import com.bellako.kiwi.common.data.UIState
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
+import com.bellako.kiwi.common.services.eventbus.EventBus
+import com.bellako.kiwi.common.services.eventbus.EventPayload
+import com.bellako.kiwi.common.services.eventbus.EventType
+import com.bellako.kiwi.features.nodes.model.INodesViewModel
+import com.bellako.kiwi.features.nodes.tests.NodesFakeViewModel
 import com.bellako.kiwi.common.screens.components.Kiwi_FixedSizeButton
 import com.bellako.kiwi.common.screens.components.Kiwi_H2
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
@@ -155,10 +160,11 @@ fun SignUpScreen4_Apps(
     usersViewModel: IUsersViewModel,
     personalityViewModel: IPersonalityViewModel,
     goalsViewModel: IGoalsViewModel,
+    nodesViewModel: INodesViewModel,
     navController: NavController,
 ) {
     SignUpScreen {
-        AppClassification(usersViewModel, personalityViewModel, navController, goalsViewModel)
+        AppClassification(usersViewModel, personalityViewModel, navController, goalsViewModel, nodesViewModel)
     }
 }
 
@@ -174,6 +180,7 @@ fun AppClassification(
     personalityViewModel: IPersonalityViewModel,
     navController: NavController,
     goalsViewModel: IGoalsViewModel,
+    nodesViewModel: INodesViewModel,
 ) {
     val context = LocalContext.current
     val packageManager = context.packageManager
@@ -296,6 +303,7 @@ fun AppClassification(
             usersViewModel = usersViewModel,
             personalityViewModel = personalityViewModel,
             goalsViewModel = goalsViewModel,
+            nodesViewModel = nodesViewModel,
             goodApps = goodApps,
             badApps = badApps,
             neutralApps = neutralApps,
@@ -341,6 +349,7 @@ fun AppClassificationColumns(
     usersViewModel: IUsersViewModel,
     personalityViewModel: IPersonalityViewModel,
     goalsViewModel: IGoalsViewModel,
+    nodesViewModel: INodesViewModel,
     goodApps: SnapshotStateList<AppInfo>,
     badApps: SnapshotStateList<AppInfo>,
     neutralApps: SnapshotStateList<AppInfo>,
@@ -468,8 +477,22 @@ fun AppClassificationColumns(
                                 goodApps.map { it.packageName },
                                 badApps.map { it.packageName },
                             )
+                            // Drive the fresh-account opening beat right here, under
+                            // the loading curtain. The map's own LaunchedEffect was
+                            // racing the backend's first-node provisioning on this
+                            // path — by awaiting the round-trip before navigating,
+                            // the map mounts with the first node already COMPLETED.
+                            val executedNode = nodesViewModel.autoExecuteFirstNode(0)
                             navController.navigate(ScreenRoutes.HOME)
                             onUpdateSuccess()
+                            executedNode?.let { node ->
+                                if (node.onExecutionEvent.isNotBlank() && node.onExecutionEvent != "_") {
+                                    EventBus.emitEvent(
+                                        EventType.valueOf(node.onExecutionEvent),
+                                        EventPayload.EntityIdPayload(node.onExecutionEntityId),
+                                    )
+                                }
+                            }
                         }
                     } else if (!fromSettings) {
                         usersViewModel.setShowAppLoading(false)
@@ -904,6 +927,7 @@ fun SignUpScreen4_Apps_Preview() {
                 ),
             navController = rememberNavController(),
             goalsViewModel = GoalsFakeViewModel(),
+            nodesViewModel = NodesFakeViewModel(),
         )
     }
 }


### PR DESCRIPTION
## Summary

High-priority polish pass fixing several race conditions and UI issues across the cold-start, sign-up, and combat-resume flows. Key areas: map music no longer flashes before combat audio on cold-start resume; the first map node is now unlocked and completed atomically under the sign-up loading curtain (eliminating a race against backend provisioning); the app-classification screen is reused from Settings with a dedicated slide transition; and a handful of smaller fixes (loading screen animation flicker, notification timing, cooldown slider, back-to-login link).

## Changes

### Game Logic / Other

- **Cold-start combat resume** (`CombatViewModel`, `MainScreen`): Added `hasResolvedCombatOnStartup` StateFlow that flips after `tryResumeActive` finishes. The loading curtain now waits on this flag (not just feature-data loading), and map music is gated behind it — so a cold-start with an active combat goes straight to combat audio with no map-music flash.
- **Loading screen animation flicker** (`LoginLoadingScreen`): Animation state is now reset to initial values *before* `present = true` flips, so the first frame of each subsequent show renders at the pre-entrance position instead of flashing the previous cycle's final frame.
- **Notification overlay timing** (`MainScreen`): The global notification overlay is suppressed while `showAppLoading` is true, preventing queued pop-ups from surfacing before the user has landed on a screen.
- **Settings → Change Apps transition** (`MainScreen`): Added `isSettingsAppsTransition` helper; the apps screen now rises from the bottom when pushed from Settings and slides back down on pop, matching the map-transition feel instead of the plain sign-up fade.

### Skill System

- **Cooldown slider** (`SkillDetailsModal`): Corrected inverted `enabled` condition on the goal-progress slider — was `!skill.isCooldown`, now `skill.isCooldown`.

### Sign-up / Nodes

- **Auto-execute first node under the loading curtain** (`SignUpScreen4_Apps`, `INodesViewModel`, `NodesViewModel`): Added `autoExecuteFirstNode(mapId)` which loads nodes, and if none are OPEN or COMPLETED, unlocks and completes the first one in a single awaited call. Sign-up invokes this before navigating to the map so the map mounts with the first node already COMPLETED. Network failures are swallowed — the flow keeps moving regardless.
- **Map-side safety net** (`MapScreen`): A `LaunchedEffect` calls `runAutoExecuteFirstNodeIfNeeded` on mount so a fresh account with all nodes still LOCKED (e.g. if the sign-up round-trip failed) still fires the opening beat.
- **"Change Apps" from Settings** (`SignUpScreen4_Apps`): Confirm now detects `fromSettings` via the back-stack. In that mode it saves and `popBackStack()` — no loading curtain, no Firebase signup event, no baseline reset.
- **Back-to-login on sign-up form** (`SignUpScreen2_Form`, `SignUpScreen1_Welcome`): Promoted `GoToLogIn` to `internal` and added it to the form screen so users can return to login from step 2.

## Schema / Migration Notes

No schema changes.

## Testing

1. **Cold-start combat resume** — kill the app mid-combat, reopen; confirm the curtain stays up until the combat screen is visible and no map music plays before combat audio.
2. **Fresh sign-up** — complete the sign-up flow through app classification; confirm the map mounts with the first node already completed and the opening beat fires without a blank map.
3. **Change Apps from Settings** — navigate Settings → Change Apps, confirm, verify it slides back to Settings without showing the loading curtain or resetting the baseline.
4. **Skill cooldown slider** — open a skill on cooldown; verify the goal-progress slider is interactable.
5. **Back-to-login link** — on sign-up step 2, verify the "Go to Login" link is visible and navigates to the login screen.
6. **Repeated loading screen shows** — trigger the loading screen multiple times (e.g. log in, log out, log in) and confirm there is no one-frame flicker of stale content.

## Related

None.