### PR TITLE
Feature/polish epic 31

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBarkBubble.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/combat/components/CombatBarkBubble.kt
@@ -10,8 +10,6 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -36,7 +34,6 @@ import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.features.combat.data.ActiveBarkDomain
 import com.bellako.kiwi.features.combat.data.BarkDismissMode
 import com.bellako.kiwi.ui.LocalKiwiColors
-import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 import kotlinx.coroutines.delay
@@ -49,7 +46,14 @@ private val BARK_MIN_WIDTH = 180.dp
 private val BARK_MAX_WIDTH = 280.dp
 private val BARK_PADDING_HORIZONTAL = 24.dp
 private val BARK_PADDING_VERTICAL = 20.dp
+
+// When the click chevron is shown it lives inside the bubble frame, so the text
+// reserves extra space at the bottom to leave room for it (size + bounce + inset).
+private val BARK_PADDING_VERTICAL_WITH_ARROW = 36.dp
 private val BARK_ARROW_SIZE = 12.dp
+
+// Gap held between the chevron and the inner bottom edge of the bubble frame.
+private val BARK_ARROW_BOTTOM_INSET = 8.dp
 
 @Composable
 fun CombatBarkBubble(
@@ -90,8 +94,8 @@ fun CombatBarkBubble(
             }
         }
 
-    Column(
-        horizontalAlignment = Alignment.CenterHorizontally,
+    Box(
+        contentAlignment = Alignment.Center,
         modifier =
             modifier
                 .alpha(appearAlpha.value)
@@ -100,36 +104,44 @@ fun CombatBarkBubble(
                     max = getResponsiveSizeWidth(BARK_MAX_WIDTH),
                 ).then(clickModifier),
     ) {
-        Box(
-            contentAlignment = Alignment.Center,
-        ) {
-            Image(
-                painter = painterResource(R.drawable.dialogue_small_bg),
-                contentDescription = null,
-                contentScale = ContentScale.FillBounds,
-                modifier = Modifier.matchParentSize(),
-            )
-            Kiwi_P2(
-                KiwiTextArguments(
-                    bark.conversation.dialog,
-                    textAlign = TextAlign.Center,
-                    color = colors.color6,
-                    modifier =
-                        Modifier.padding(
-                            horizontal = getResponsiveSizeWidth(BARK_PADDING_HORIZONTAL),
-                            vertical = getResponsiveSizeHeight(BARK_PADDING_VERTICAL),
-                        ),
-                ),
-            )
-        }
+        Image(
+            painter = painterResource(R.drawable.dialogue_small_bg),
+            contentDescription = null,
+            contentScale = ContentScale.FillBounds,
+            modifier = Modifier.matchParentSize(),
+        )
+        Kiwi_P2(
+            KiwiTextArguments(
+                bark.conversation.dialog,
+                textAlign = TextAlign.Center,
+                color = colors.color6,
+                modifier =
+                    Modifier.padding(
+                        start = getResponsiveSizeWidth(BARK_PADDING_HORIZONTAL),
+                        end = getResponsiveSizeWidth(BARK_PADDING_HORIZONTAL),
+                        top = getResponsiveSizeHeight(BARK_PADDING_VERTICAL),
+                        // Reserve room for the chevron so it sits inside the
+                        // frame without overlapping the text.
+                        bottom =
+                            getResponsiveSizeHeight(
+                                if (isAuto) BARK_PADDING_VERTICAL else BARK_PADDING_VERTICAL_WITH_ARROW,
+                            ),
+                    ),
+            ),
+        )
         if (!isAuto) {
-            BarkClickIndicator()
+            BarkClickIndicator(
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomCenter)
+                        .padding(bottom = getResponsiveSizeHeight(BARK_ARROW_BOTTOM_INSET)),
+            )
         }
     }
 }
 
 @Composable
-private fun BarkClickIndicator() {
+private fun BarkClickIndicator(modifier: Modifier = Modifier) {
     val transition = rememberInfiniteTransition(label = "bark_arrow_bounce")
     val offsetY by transition.animateFloat(
         initialValue = 0f,
@@ -141,20 +153,12 @@ private fun BarkClickIndicator() {
             ),
         label = "bark_arrow_offset",
     )
-    Box(
+    Kiwi_Image(
+        R.drawable.ic_dialogue_arrow,
+        "Tap to continue",
         modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(top = getResponsiveSizeHeight(Spacing.xSmall)),
-        contentAlignment = Alignment.Center,
-    ) {
-        Kiwi_Image(
-            R.drawable.ic_dialogue_arrow,
-            "Tap to continue",
-            modifier =
-                Modifier
-                    .size(getResponsiveSizeWidth(BARK_ARROW_SIZE), getResponsiveSizeHeight(BARK_ARROW_SIZE))
-                    .offset(y = getResponsiveSizeHeight(offsetY.dp)),
-        )
-    }
+            modifier
+                .size(getResponsiveSizeWidth(BARK_ARROW_SIZE), getResponsiveSizeHeight(BARK_ARROW_SIZE))
+                .offset(y = getResponsiveSizeHeight(offsetY.dp)),
+    )
 }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/DialogueScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -62,6 +61,11 @@ import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
 
 private const val DIALOGUE_ADVANCE_MS = 450
+
+// Distance the advance chevron is held above the inner bottom edge of the
+// dialogue frame. Scaled by width (like the FillWidth background) so the gap
+// stays proportional to the frame on every screen and never lands on the border.
+private val ARROW_BOTTOM_INSET = 12.dp
 
 @Composable
 @Suppress("MagicNumber", "LongMethod")
@@ -216,10 +220,13 @@ fun DialogueScreen(
                     "Arrow",
                     modifier =
                         Modifier
-                            .fillMaxWidth()
                             .align(Alignment.BottomCenter)
+                            // Hold the chevron a fixed gap inside the frame's
+                            // bottom edge, then let the bounce travel upward
+                            // from there so it never crosses the border.
+                            .padding(bottom = getResponsiveSizeWidth(ARROW_BOTTOM_INSET))
                             .size(getResponsiveSizeWidth(10.dp), getResponsiveSizeHeight(10.dp))
-                            .offset(y = getResponsiveSizeHeight((offsetY - 12f).dp))
+                            .offset(y = getResponsiveSizeHeight(offsetY.dp))
                             .alpha(if (showAdvanceChevron) 1f else 0f)
                             .then(
                                 if (showAdvanceChevron) {

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/nodes/screens/Nodes.kt
@@ -69,6 +69,7 @@ import com.bellako.kiwi.common.screens.components.Kiwi_H1
 import com.bellako.kiwi.common.screens.components.Kiwi_H2
 import com.bellako.kiwi.common.screens.components.Kiwi_HoldButton
 import com.bellako.kiwi.common.screens.components.Kiwi_Image
+import com.bellako.kiwi.common.services.eventbus.EventType
 import com.bellako.kiwi.features.appbar.screens.AppBarScreen
 import com.bellako.kiwi.features.map.data.MapState
 import com.bellako.kiwi.features.nodes.data.NodeStatus
@@ -265,6 +266,13 @@ fun NodeOnMap(
 ) {
     val centered = nodeViewportOffset(node, mapState)
 
+    // Only map-portal nodes keep their name label pinned on the map. Every
+    // other node's name shouldn't persist on the map screen, so it's dropped
+    // here — leaving the label exclusively for SWITCH_MAP nodes, which act as
+    // gateways the player needs to be able to identify at a glance.
+    val persistentName =
+        node.displayName.takeIf { node.onExecutionEvent == EventType.SWITCH_MAP.name }.orEmpty()
+
     Box(
         modifier =
             Modifier
@@ -277,7 +285,7 @@ fun NodeOnMap(
             node.status,
             node.icon,
             mapState.scale,
-            node.displayName,
+            persistentName,
             revealScale,
             nameAlpha,
             iconAnimationReady,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/objectives/ObjectivesScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/objectives/ObjectivesScreen.kt
@@ -225,3 +225,34 @@ fun ObjectivesScreen_Preview() {
         }
     }
 }
+
+@RequiresApi(Build.VERSION_CODES.O)
+@SuppressLint("ViewModelConstructorInComposable")
+@Preview(name = "Small Phone", widthDp = 320, heightDp = 640)
+@Preview(name = "Medium Phone", widthDp = 392, heightDp = 800)
+@Preview(name = "Large Phone", widthDp = 480, heightDp = 900)
+@Composable
+fun ObjectivesScreen_ExpandedQuest_Preview() {
+    Kiwi_Theme {
+        val fakeViewModel = QuestsFakeViewModel(QuestsTestFactory.validQuestsState())
+
+        Scaffold(
+            bottomBar = {
+                AppBarScreen(navController = rememberNavController())
+            },
+        ) { paddingValues ->
+            Box(
+                modifier =
+                    Modifier
+                        .padding(paddingValues)
+                        .fillMaxSize(),
+            ) {
+                ObjectivesScreen(
+                    questsViewModel = fakeViewModel,
+                    goalsViewModel = GoalsFakeViewModel(),
+                    focusedQuestId = 1,
+                )
+            }
+        }
+    }
+}

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/quests/screens/Quest.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/quests/screens/Quest.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -21,8 +23,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.style.LineHeightStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.zIndex
 import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
@@ -31,12 +37,15 @@ import com.bellako.kiwi.common.screens.components.Kiwi_Image
 import com.bellako.kiwi.common.screens.components.Kiwi_Label1
 import com.bellako.kiwi.common.screens.components.Kiwi_P2
 import com.bellako.kiwi.common.screens.components.Kiwi_Spacer
+import com.bellako.kiwi.common.screens.components.rememberTextWidthScale
 import com.bellako.kiwi.features.quests.data.QuestDomain
 import com.bellako.kiwi.features.quests.data.SubquestDomain
 import com.bellako.kiwi.features.quests.data.SubquestStatus
 import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
+
+private const val SUBQUEST_TITLE_LINE_HEIGHT = 1.2f
 
 // ACTIVE QUESTS
 @Composable
@@ -199,11 +208,12 @@ fun Subquest(
 
         // TEXT
         Column {
-            Kiwi_Label1(
-                KiwiTextArguments(
-                    text = subquest.name,
-                ),
-            )
+            Box(
+                modifier = Modifier.height(getResponsiveSizeHeight(20.dp)),
+                contentAlignment = Alignment.CenterStart,
+            ) {
+                SubquestTitle(subquest.name)
+            }
 
             Kiwi_Label1(
                 KiwiTextArguments(
@@ -213,6 +223,30 @@ fun Subquest(
             )
         }
     }
+}
+
+// Subquest title rendered with font padding disabled and a centered line height so the
+// glyph sits at the true vertical center, aligning it with the status icon's y-axis.
+@Composable
+private fun SubquestTitle(text: String) {
+    val scale = rememberTextWidthScale()
+    val style = MaterialTheme.typography.labelLarge
+
+    Text(
+        text = text,
+        color = Color.White,
+        style =
+            style.copy(
+                fontSize = (style.fontSize.value * scale).sp,
+                lineHeight = (style.fontSize.value * scale * SUBQUEST_TITLE_LINE_HEIGHT).sp,
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
+                lineHeightStyle =
+                    LineHeightStyle(
+                        alignment = LineHeightStyle.Alignment.Center,
+                        trim = LineHeightStyle.Trim.None,
+                    ),
+            ),
+    )
 }
 
 // HELPERS

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/data/Password.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/data/Password.kt
@@ -1,13 +1,31 @@
 package com.bellako.kiwi.features.users.data
 
+// A single rule a password must satisfy, pairing the human-readable description
+// shown to the user with the predicate that enforces it. Keeping both together
+// means the explanation and the validation can never drift apart.
+private data class PasswordRule(
+    val description: String,
+    val isSatisfiedBy: (String) -> Boolean,
+)
+
 @JvmInline
 value class Password private constructor(
     val value: String,
 ) {
     companion object {
-        private val PASSWORD_REGEX_LENGTH = Regex("^.{8,}$")
+        const val MIN_LENGTH = 8
 
-        fun isValid(password: String): Boolean = PASSWORD_REGEX_LENGTH.matches(password)
+        private val RULES: List<PasswordRule> =
+            listOf(
+                PasswordRule("At least $MIN_LENGTH characters long") { it.length >= MIN_LENGTH },
+            )
+
+        // The rules the given password currently fails, used to tell the user
+        // exactly why an entry is rejected. Empty when the password is valid.
+        fun unmetRequirements(password: String): List<String> =
+            RULES.filter { !it.isSatisfiedBy(password) }.map { it.description }
+
+        fun isValid(password: String): Boolean = RULES.all { it.isSatisfiedBy(password) }
 
         fun of(password: String): Result<Password> =
             if (isValid(password)) {
@@ -15,11 +33,7 @@ value class Password private constructor(
             } else {
                 Result.failure(
                     IllegalArgumentException(
-                        if (!PASSWORD_REGEX_LENGTH.matches(password)) {
-                            "Password should be at least 8 characters long"
-                        } else {
-                            "Invalid password format"
-                        },
+                        "Password should be at least $MIN_LENGTH characters long",
                     ),
                 )
             }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/model/UsersViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/model/UsersViewModel.kt
@@ -93,14 +93,10 @@ class UsersViewModel
                 },
             )
 
-        override fun checkPasswordValid(): Boolean =
-            Password.of(_state.value.password).fold(
-                onSuccess = { _ -> true },
-                onFailure = { err ->
-                    setUiState(UIState.Error(err.message.orEmpty()))
-                    false
-                },
-            )
+        // The "why" is surfaced inline next to the password field (see the
+        // sign-up form), so this only needs to gate submission — no error is
+        // pushed to the shared UI state here to avoid a duplicate message.
+        override fun checkPasswordValid(): Boolean = Password.isValid(_state.value.password)
 
         @RequiresApi(Build.VERSION_CODES.O)
         override fun getRegisterDate(): LocalDate = stringToDate(_state.value.registerDate)

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen2_Form.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/screens/SignUpScreen2_Form.kt
@@ -2,13 +2,17 @@ package com.bellako.kiwi.features.users.screens
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -27,6 +31,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.bellako.kiwi.analytics.FirebaseEventNames
@@ -49,6 +54,7 @@ import com.bellako.kiwi.features.personality.model.IPersonalityViewModel
 import com.bellako.kiwi.features.personality.tests.PersonalityFakeViewModel
 import com.bellako.kiwi.features.nodes.screens.LocalNodeEntryTransition
 import com.bellako.kiwi.features.personality.tests.PersonalityTestFactory.validPersonalityDTO
+import com.bellako.kiwi.features.users.data.Password
 import com.bellako.kiwi.features.users.data.UsersState
 import com.bellako.kiwi.features.users.model.IUsersViewModel
 import com.bellako.kiwi.features.users.tests.UsersFakeViewModel
@@ -219,6 +225,11 @@ private fun SignUpForm(
 ) {
     val kiwiColors = LocalKiwiColors.current
 
+    // Live typing feedback surfaces password problems on its own; this flag
+    // additionally reveals them after a submit attempt so an empty password
+    // (nothing typed yet) is still explained instead of silently blocking.
+    var attemptedSubmit by remember { mutableStateOf(false) }
+
     // Veil the step change into the questionnaire. rememberCoroutineScope (not
     // the detached CoroutineScope used for the async signup below) so the veil
     // Animatable has a frame clock.
@@ -237,6 +248,7 @@ private fun SignUpForm(
         isLoading = isLoading,
         usersViewModel = usersViewModel,
         usersState = usersState,
+        showErrorsWhenEmpty = attemptedSubmit,
     )
 
     Kiwi_Spacer(Spacing.xLarge)
@@ -250,6 +262,7 @@ private fun SignUpForm(
             ),
         color = kiwiColors.color8,
         onClick = {
+            attemptedSubmit = true
             CoroutineScope(Dispatchers.Main).launch {
                 if (personalityViewModel.checkRealNameValid() && personalityViewModel.checkKnightNameValid()) {
                     personalityViewModel.resetUiState()
@@ -330,8 +343,16 @@ private fun SignUpForm_Users(
     isLoading: Boolean,
     usersViewModel: IUsersViewModel,
     usersState: UsersState,
+    showErrorsWhenEmpty: Boolean,
 ) {
     val kiwiColors = LocalKiwiColors.current
+
+    // Explain why a password is rejected: the rules it fails, shown live while
+    // the user types and — once a submit has been attempted — even for an empty
+    // field. A valid password shows nothing.
+    val unmetRequirements = Password.unmetRequirements(usersState.password)
+    val showPasswordErrors =
+        unmetRequirements.isNotEmpty() && (usersState.password.isNotEmpty() || showErrorsWhenEmpty)
 
     Kiwi_InputField(
         enabled = !isLoading,
@@ -369,6 +390,46 @@ private fun SignUpForm_Users(
         color = kiwiColors.color3A,
         testTag = UsersTestTags.PASSWORD_FIELD,
     )
+
+    if (showPasswordErrors) {
+        PasswordValidationErrors(unmetRequirements)
+    }
+}
+
+@Suppress("MagicNumber")
+@Composable
+private fun PasswordValidationErrors(unmetRequirements: List<String>) {
+    val kiwiColors = LocalKiwiColors.current
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(top = getResponsiveSizeHeight(Spacing.xSmall))
+                .testTag(UsersTestTags.PASSWORD_ERROR),
+        verticalArrangement = Arrangement.spacedBy(getResponsiveSizeHeight(Spacing.xSmall)),
+    ) {
+        unmetRequirements.forEach { requirement ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(getResponsiveSizeHeight(Spacing.small)),
+            ) {
+                Box(
+                    modifier =
+                        Modifier
+                            .size(getResponsiveSizeHeight(6.dp))
+                            .background(color = kiwiColors.colorR, shape = CircleShape),
+                )
+                Kiwi_Label2(
+                    KiwiTextArguments(
+                        requirement,
+                        color = kiwiColors.colorR,
+                    ),
+                )
+            }
+        }
+    }
 }
 
 @Composable

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/tests/UsersFakeViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/tests/UsersFakeViewModel.kt
@@ -60,14 +60,7 @@ class UsersFakeViewModel(
             },
         )
 
-    override fun checkPasswordValid(): Boolean =
-        Password.of(_state.value!!.password).fold(
-            onSuccess = { _ -> true },
-            onFailure = { err ->
-                setUiState(UIState.Error(err.message.orEmpty()))
-                false
-            },
-        )
+    override fun checkPasswordValid(): Boolean = Password.isValid(_state.value!!.password)
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun getRegisterDate(): LocalDate = stringToDate(_state.value?.registerDate.orEmpty())

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/users/tests/UsersTestTags.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/users/tests/UsersTestTags.kt
@@ -3,6 +3,7 @@ package com.bellako.kiwi.features.users.tests
 object UsersTestTags {
     const val EMAIL_FIELD = "Login_email_field"
     const val PASSWORD_FIELD = "Login_password_field"
+    const val PASSWORD_ERROR = "Login_password_error"
 
     const val SIGNUP_BUTTON = "Login_signup_button"
     const val LOGIN_BUTTON = "Login_login_button"


### PR DESCRIPTION
## Summary

Polish pass on Epic 31 covering four areas: (1) the sign-up password field now surfaces inline constraint violations as the user types, using a new `PasswordRule`-based API that keeps the error message and the validation predicate together so they can never drift apart; (2) the "tap to continue" advance chevron in both `CombatBarkBubble` and `DialogueScreen` is repositioned inside its frame with proper bottom-inset padding instead of a negative-offset hack, so it no longer overflows the border; (3) subquest titles are vertically centered with their status icons by disabling font padding and using `LineHeightStyle.Alignment.Center`; (4) node name labels on the map are now only pinned for `SWITCH_MAP` (location portal) nodes — all other node types drop the persistent label.

## Changes

### Dialog & Bark System

- **`CombatBarkBubble`** — switched outer layout from `Column` to `Box`; text now reserves extra bottom padding (`BARK_PADDING_VERTICAL_WITH_ARROW`) when the tap-to-dismiss chevron is present, and `BarkClickIndicator` is positioned with `Alignment.BottomCenter` + `BARK_ARROW_BOTTOM_INSET` so it sits inside the frame without overlapping text.
- **`DialogueScreen`** — replaced the `fillMaxWidth` + negative Y-offset approach with `Alignment.BottomCenter` + `padding(bottom = ARROW_BOTTOM_INSET)`, scaled by width to stay proportional to the frame on all screen sizes.

### Game Logic / Other

- **Nodes map** — `NodeOnMap` now passes an empty name for all non-`SWITCH_MAP` nodes; only location-portal nodes keep a visible label pinned on the map.
- **Subquest title** — new `SubquestTitle` composable with `includeFontPadding = false` and `LineHeightStyle.Alignment.Center` ensures glyph baseline aligns with the status icon. Wrapped in a fixed-height `Box(20.dp)` for stable layout.
- **ObjectivesScreen preview** — added `ObjectivesScreen_ExpandedQuest_Preview` at three sizes (320, 392, 480 dp wide) with a focused quest to cover the expanded-subquest layout in Compose Preview.
- **Password validation (sign-up)** — `Password` refactored to a `PasswordRule` list with a new `unmetRequirements()` API. Sign-up form shows a red bullet list of failing rules live while typing, and after a submit attempt reveals them even for an empty field (`attemptedSubmit` flag). `checkPasswordValid()` simplified in both `UsersViewModel` and `UsersFakeViewModel` — the "why" is now owned by the inline UI, not the shared `UIState.Error`. Added `PASSWORD_ERROR` test tag.

## Schema / Migration Notes

No schema changes.

## Testing

Against `kiwi_db_dev` or a local dev build:

- **Password validation** — on the sign-up form, type a password shorter than 8 characters → red "At least 8 characters long" bullet appears below the field; clear the field and tap the submit button → same bullet appears (empty-field case); meet the requirement → bullet disappears.
- **Bark bubble chevron** — trigger a manual (tap-to-dismiss) combat bark → confirm the bounce chevron sits fully inside the bubble frame with a visible gap from the border and no text overlap.
- **Dialogue chevron** — advance through a standard dialogue → confirm the chevron sits inside the frame without clipping the bottom border.
- **Node labels** — open the map with mixed node types → only SWITCH_MAP (portal) nodes show a persistent name label; all others show no name.
- **Subquest alignment** — open a quest with multiple subquests → verify the title text is visually centered on the same axis as the status icon to the left.

## Related

None.