### PR TITLE
Yesterday fix

### DIFF
--- a/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/conversations/screens/ConversationScreen.kt
@@ -98,6 +98,7 @@ fun ConversationScreen(
     conversation: ConversationDomain,
     viewModel: ConversationViewModel? = null,
 ) {
+    val kiwiColor = LocalKiwiColors.current
     val infiniteTransition = rememberInfiniteTransition(label = "arrow_bounce")
     val offsetY by infiniteTransition.animateFloat(
         initialValue = 0f,
@@ -198,7 +199,14 @@ fun ConversationScreen(
                             !typewriter.isComplete -> typewriter.skip()
                             conversation.options.isEmpty() -> advance()
                         }
-                    },
+                    }.background(
+                        Brush.verticalGradient(
+                            0f to Color.Transparent,
+                            0.2f to Color.Transparent,
+                            0.8f to kiwiColor.color2,
+                            1f to kiwiColor.color2,
+                        ),
+                    ),
         ) {
             val charExtraX =
                 if (isProtagonist) 0.dp else -screenWidth * (1f - characterProgress.value)
@@ -252,20 +260,12 @@ private fun DialogueBox(
     alpha: Float,
     modifier: Modifier = Modifier,
 ) {
-    val kiwiColor = LocalKiwiColors.current
     val context = LocalContext.current
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
-                .alpha(alpha)
-                .background(
-                    Brush.verticalGradient(
-                        -0.2f to Color.Transparent,
-                        0.5f to kiwiColor.color2,
-                        1f to kiwiColor.color2,
-                    ),
-                ),
+                .alpha(alpha),
     ) {
         Box(
             contentAlignment = Alignment.Center,
@@ -358,8 +358,8 @@ private fun ConversationOptionsPanel(
         modifier =
             Modifier
                 .fillMaxWidth()
-                .alpha(alpha)
-                .background(kiwiColor.color2),
+                .alpha(alpha),
+//                .background(kiwiColor.color2),
     ) {
         val optionHeight = getResponsiveSizeHeight(50.dp)
         val maxVisible = 3
@@ -451,7 +451,7 @@ fun ConversationScreen_Preview() {
                         1L,
                         "Conversación de prueba",
                         ConversationType.FULL,
-                        "liria_neutral",
+                        "character_liria_base",
                         null,
                         null,
                         false,

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
@@ -2,6 +2,7 @@ package com.bellako.kiwi.features.goals.model
 
 import android.os.Build
 import androidx.annotation.RequiresApi
+import android.util.Log
 import com.bellako.kiwi.common.data.UIState
 import com.bellako.kiwi.common.model.BaseViewModel
 import com.bellako.kiwi.common.services.eventbus.EventBus
@@ -27,6 +28,7 @@ import jakarta.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.time.LocalDate
@@ -58,234 +60,174 @@ class GoalsViewModel
         @RequiresApi(Build.VERSION_CODES.O)
         private fun getCurrentDate(): String = dateToString(LocalDate.now())
 
-        /**
-         * Actualiza un goal en todas las entradas del cache donde aparezca
-         * @param updatedGoal El goal actualizado
-         */
         @RequiresApi(Build.VERSION_CODES.O)
         private suspend fun updateGoalInCache(updatedGoal: UserGoalStatusDomain) {
             cacheMutex.withLock {
-                // Actualizar en cachedGoalsByDate
                 val keys = cachedGoalsByDate.keys.toList()
                 keys.forEach { date ->
                     val goals = cachedGoalsByDate[date] ?: emptyList()
                     val updatedList = goals.map { goal -> if (goal.id == updatedGoal.id) updatedGoal else goal }
                     cachedGoalsByDate[date] = updatedList
                 }
-
-                // Actualizar en cachedGoalsInProgress si existe
                 cachedGoalsInProgress = cachedGoalsInProgress?.map { goal -> if (goal.id == updatedGoal.id) updatedGoal else goal }
-
-                // Mantener fecha de cache actualizada
                 cacheDate = getCurrentDate()
-
                 EventBus.emitEvent(EventType.DAILY_GOALS_UPDATED, EventPayload.EmptyPayload())
             }
         }
 
-        /**
-         * Añade nuevas goals al cache de la fecha correspondiente
-         * @param newGoals Lista de goals creadas
-         * @param date Fecha en formato yyyy-MM-dd
-         */
         @RequiresApi(Build.VERSION_CODES.O)
-        private suspend fun addGoalsToCache(
-            newGoals: List<UserGoalStatusDomain>,
-            date: String,
-        ) {
+        private suspend fun addGoalsToCache(newGoals: List<UserGoalStatusDomain>, date: String) {
             cacheMutex.withLock {
                 val existing = cachedGoalsByDate[date]
-                if (existing == null) {
-                    cachedGoalsByDate[date] = newGoals
-                } else {
-                    cachedGoalsByDate[date] = existing + newGoals
-                }
+                cachedGoalsByDate[date] = if (existing == null) newGoals else existing + newGoals
                 cacheDate = getCurrentDate()
             }
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
         private suspend fun createGoals(goals: List<GoalState>): Result<Unit> {
-            setIsLoading(true)
+            _state.update { it.copy(isLoading = true, error = null) }
             setUiState(UIState.Loading)
-            _state.value = _state.value.copy(isLoading = true, error = null)
 
-            val goalsDTO = goals.map { UserGoalStatusDataMapper.toDTO(it) }
-            val result = repository.createGoals(goalsDTO)
+            val result = repository.createGoals(goals.map { UserGoalStatusDataMapper.toDTO(it) })
 
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            return handleResultSuspend(result) {
-                val resultDTOs = result.getOrNull()!!
-                _state.value =
-                    _state.value.copy(
-                        goals = resultDTOs.map { UserGoalStatusDataMapper.toState(it) },
-                        isLoading = false,
-                        error = null,
-                    )
-                val newGoalsDomain = resultDTOs.map { UserGoalStatusDataMapper.toDomain(it) }
-                val today = dateToString(LocalDate.now())
-                addGoalsToCache(newGoalsDomain, today)
-
-                EventBus.emitEvent(EventType.DAILY_GOALS_UPDATED, EventPayload.EmptyPayload())
-            }.also {
-                if (it.isFailure) {
-                    _state.value =
-                        _state.value.copy(
+            return result.fold(
+                onSuccess = { resultDTOs ->
+                    val newGoalsDomain = resultDTOs.map { UserGoalStatusDataMapper.toDomain(it) }
+                    _state.update { currentState ->
+                        currentState.copy(
+                            goals = resultDTOs.map { UserGoalStatusDataMapper.toState(it) },
                             isLoading = false,
-                            error = it.exceptionOrNull()?.message,
+                            error = null
                         )
+                    }
+                    addGoalsToCache(newGoalsDomain, dateToString(LocalDate.now()))
+                    EventBus.emitEvent(EventType.DAILY_GOALS_UPDATED, EventPayload.EmptyPayload())
+                    setUiState(UIState.Success(Unit))
+                    Result.success(Unit)
+                },
+                onFailure = { throwable ->
+                    _state.update { it.copy(isLoading = false, error = throwable.message) }
+                    setUiState(mapExceptionToUIState(throwable))
+                    Result.failure(throwable)
                 }
-            }
+            )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun updateGoalProgress(goalId: Long): Result<UserGoalStatusDomain> {
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-            _state.value = _state.value.copy(isLoading = true, error = null)
-
+            _state.update { it.copy(isLoading = true, error = null) }
             val result = repository.updateGoalProgress(goalId)
 
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            // Manejar explícitamente para poder usar suspend dentro del flujo
-            return if (result.isSuccess) {
-                val updatedDTO = result.getOrNull()!!
-                val updatedState = UserGoalStatusDataMapper.toState(updatedDTO)
-                val updatedGoals = _state.value.goals.map { if (it.id == updatedState.id) updatedState else it }
-                _state.value = _state.value.copy(goals = updatedGoals, isLoading = false, error = null)
-                val updatedDomain = UserGoalStatusDataMapper.toDomain(updatedDTO)
-                updateGoalInCache(updatedDomain)
-                Result.success(updatedDomain)
-            } else {
-                _state.value = _state.value.copy(isLoading = false, error = result.exceptionOrNull()?.message)
-                Result.failure(result.exceptionOrNull() ?: Exception("Unknown error"))
-            }
+            return result.fold(
+                onSuccess = { updatedDTO ->
+                    val updatedDomain = UserGoalStatusDataMapper.toDomain(updatedDTO)
+                    val updatedState = UserGoalStatusDataMapper.toState(updatedDomain)
+                    _state.update { currentState ->
+                        val updatedList = currentState.goals.map { if (it.id == updatedState.id) updatedState else it }
+                        currentState.copy(goals = updatedList, isLoading = false)
+                    }
+                    updateGoalInCache(updatedDomain)
+                    Result.success(updatedDomain)
+                },
+                onFailure = { throwable ->
+                    _state.update { it.copy(isLoading = false, error = throwable.message) }
+                    Result.failure(throwable)
+                }
+            )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun updateGoal(goal: UserGoalStatusDomain): Result<UserGoalStatusDomain> {
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-            _state.value = _state.value.copy(isLoading = true, error = null)
-
+            _state.update { it.copy(isLoading = true, error = null) }
             val result = repository.updateGoal(UserGoalStatusDataMapper.toDTO(goal))
 
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            return if (result.isSuccess) {
-                val updatedDTO = result.getOrNull()!!
-                val updatedState = UserGoalStatusDataMapper.toState(updatedDTO)
-                val updatedGoals = _state.value.goals.map { if (it.id == updatedState.id) updatedState else it }
-
-                _state.value = _state.value.copy(goals = updatedGoals, isLoading = false, error = null)
-
-                val updatedDomain = UserGoalStatusDataMapper.toDomain(updatedDTO)
-
-                updateGoalInCache(updatedDomain)
-
-                Result.success(updatedDomain)
-            } else {
-                _state.value = _state.value.copy(isLoading = false, error = result.exceptionOrNull()?.message)
-                Result.failure(result.exceptionOrNull() ?: Exception("Unknown error"))
-            }
-        }
-
-        @RequiresApi(Build.VERSION_CODES.O)
-        override suspend fun createGoalsFromDefinitions(goalDefinitions: List<GoalDomain>): Result<Unit> {
-            if (goalDefinitions.isEmpty()) {
-                return Result.failure(IllegalArgumentException("La lista de sugerencias está vacía"))
-            }
-            val today = dateToString(LocalDate.now())
-            val goalsToCreate = goalDefinitions.map { GoalDataMapper.toUserGoalStatusState(it, today) }
-            cacheMutex.withLock {
-                cachedGoalDefinitions = null
-                cachedGoalsByDate.remove(today)
-            }
-            return createGoals(goalsToCreate)
+            return result.fold(
+                onSuccess = { updatedDTO ->
+                    val updatedDomain = UserGoalStatusDataMapper.toDomain(updatedDTO)
+                    val updatedState = UserGoalStatusDataMapper.toState(updatedDomain)
+                    _state.update { currentState ->
+                        val updatedList = currentState.goals.map { if (it.id == updatedState.id) updatedState else it }
+                        currentState.copy(goals = updatedList, isLoading = false)
+                    }
+                    updateGoalInCache(updatedDomain)
+                    Result.success(updatedDomain)
+                },
+                onFailure = { throwable ->
+                    _state.update { it.copy(isLoading = false, error = throwable.message) }
+                    Result.failure(throwable)
+                }
+            )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun completeGoal(goalId: Long): Result<Unit> {
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-            _state.value = _state.value.copy(isLoading = true, error = null)
-
+            _state.update { it.copy(isLoading = true, error = null) }
             val result = repository.completeGoal(goalId)
 
-            setIsLoading(false)
-            setUiState(UIState.Idle)
+            return result.fold(
+                onSuccess = { responseDTO ->
+                    val updatedDomain = UserGoalStatusDataMapper.toDomain(responseDTO)
+                    val updatedState = UserGoalStatusDataMapper.toState(updatedDomain)
+                    
+                    _state.update { currentState ->
+                        val updatedList = currentState.goals.map { if (it.id == updatedState.id) updatedState else it }
+                        currentState.copy(goals = updatedList, isLoading = false)
+                    }
 
-            return handleResultSuspend(result) {
-                val updatedGoal = UserGoalStatusDataMapper.toState(result.getOrNull()!!)
-                val updatedGoals = _state.value.goals.map { if (it.id == updatedGoal.id) updatedGoal else it }
-                _state.value = _state.value.copy(goals = updatedGoals, isLoading = false, error = null)
+                    if (updatedDomain.onCompletedEvent != "_") {
+                        try {
+                            val eventName = updatedDomain.onCompletedEvent.uppercase().trim()
+                            val eventType = EventType.valueOf(eventName)
+                            EventBus.emitEvent(eventType, EventPayload.EntityIdPayload(updatedDomain.onCompletedEntityId))
+                        } catch (e: Exception) {
+                            Log.e("GoalsViewModel", "Event emission failed for: ${updatedDomain.onCompletedEvent}", e)
+                        }
+                    }
 
-                val updatedDomain = UserGoalStatusDataMapper.toDomain(result.getOrNull()!!)
-
-                EventBus.emitEvent(EventType.DAILY_GOALS_UPDATED, EventPayload.EmptyPayload())
-
-                if (updatedDomain.onCompletedEvent != "_") {
-                    EventBus.emitEvent(
-                        EventType.valueOf(updatedDomain.onCompletedEvent),
-                        EventPayload.EntityIdPayload(updatedDomain.onCompletedEntityId),
-                    )
+                    updateGoalInCache(updatedDomain)
+                    usersRepository.getMyUserPoints()
+                    Result.success(Unit)
+                },
+                onFailure = { throwable ->
+                    _state.update { it.copy(isLoading = false, error = throwable.message) }
+                    Result.failure(throwable)
                 }
-
-                updateGoalInCache(updatedDomain)
-                usersRepository.getMyUserPoints() // Refrescar puntos al completar goal
-            }.also {
-                if (it.isFailure) {
-                    _state.value = _state.value.copy(isLoading = false, error = it.exceptionOrNull()?.message)
-                }
-            }
+            )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun uncompleteGoal(goalId: Long): Result<Unit> {
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-            _state.value = _state.value.copy(isLoading = true, error = null)
-
+            _state.update { it.copy(isLoading = true, error = null) }
             val result = repository.uncompleteGoal(goalId)
 
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            return handleResultSuspend(result) {
-                val updatedGoal = UserGoalStatusDataMapper.toState(result.getOrNull()!!)
-                val updatedGoals = _state.value.goals.map { if (it.id == updatedGoal.id) updatedGoal else it }
-                _state.value = _state.value.copy(goals = updatedGoals, isLoading = false, error = null)
-                val updatedDomain = UserGoalStatusDataMapper.toDomain(result.getOrNull()!!)
-                updateGoalInCache(updatedDomain)
-            }.also {
-                if (it.isFailure) {
-                    _state.value = _state.value.copy(isLoading = false, error = it.exceptionOrNull()?.message)
+            return result.fold(
+                onSuccess = { responseDTO ->
+                    val updatedDomain = UserGoalStatusDataMapper.toDomain(responseDTO)
+                    val updatedState = UserGoalStatusDataMapper.toState(updatedDomain)
+                    _state.update { currentState ->
+                        val updatedList = currentState.goals.map { if (it.id == updatedState.id) updatedState else it }
+                        currentState.copy(goals = updatedList, isLoading = false)
+                    }
+                    updateGoalInCache(updatedDomain)
+                    Result.success(Unit)
+                },
+                onFailure = { throwable ->
+                    _state.update { it.copy(isLoading = false, error = throwable.message) }
+                    Result.failure(throwable)
                 }
-            }
+            )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun getGoalsByDate(date: String): Result<List<UserGoalStatusDomain>> {
-            // Comprobar cache atómicamente
             cacheMutex.withLock {
                 if (cachedGoalsByDate.containsKey(date) && cacheDate == getCurrentDate()) {
                     return Result.success(cachedGoalsByDate[date]!!)
                 }
             }
 
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-
             val result = repository.getGoalsByDate(stringToDate(date))
-
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
             return result.map { goalDTOs ->
                 val domainGoals = goalDTOs?.map { UserGoalStatusDataMapper.toDomain(it) } ?: emptyList()
                 cacheMutex.withLock {
@@ -297,26 +239,18 @@ class GoalsViewModel
         }
 
         override suspend fun loadAllGoals(): Result<Unit> {
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-            _state.value = _state.value.copy(isLoading = true, error = null)
-
+            _state.update { it.copy(isLoading = true, error = null) }
             val result = repository.getAllGoals()
-
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            return handleResult(result) {
-                _state.value = _state.value.copy(isLoading = false, error = null)
-            }.also {
-                if (it.isFailure) {
-                    _state.value =
-                        _state.value.copy(
-                            isLoading = false,
-                            error = it.exceptionOrNull()?.message,
-                        )
+            return result.fold(
+                onSuccess = {
+                    _state.update { it.copy(isLoading = false) }
+                    Result.success(Unit)
+                },
+                onFailure = { throwable ->
+                    _state.update { it.copy(isLoading = false, error = throwable.message) }
+                    Result.failure(throwable)
                 }
-            }
+            )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
@@ -327,17 +261,8 @@ class GoalsViewModel
                 }
             }
 
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-
-            val result = repository.getGoalsInProgress()
-
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            return result.map { goalDTOs ->
+            return repository.getGoalsInProgress().map { goalDTOs ->
                 val domainGoals = goalDTOs.map { UserGoalStatusDataMapper.toDomain(it) }
-                // Guardar en cache
                 cacheMutex.withLock {
                     cachedGoalsInProgress = domainGoals
                     cacheDate = getCurrentDate()
@@ -354,30 +279,17 @@ class GoalsViewModel
                 }
             }
 
-            setIsLoading(true)
-            setUiState(UIState.Loading)
-
-            val result = repository.getGoalDefinitions()
-
-            setIsLoading(false)
-            setUiState(UIState.Idle)
-
-            return result.map { goalDTOs ->
+            return repository.getGoalDefinitions().map { goalDTOs ->
                 val goalDomains = goalDTOs.map { GoalDataMapper.toDomain(it) }
-                cacheMutex.withLock {
-                    cachedGoalDefinitions = goalDomains
-                }
+                cacheMutex.withLock { cachedGoalDefinitions = goalDomains }
                 goalDomains
             }
         }
 
         override suspend fun invalidateGoalsInProgressCache() {
-            cacheMutex.withLock {
-                cachedGoalsInProgress = null
-            }
+            cacheMutex.withLock { cachedGoalsInProgress = null }
         }
 
-        // Limpiar cache cuando se destruye el ViewModel
         override fun onCleared() {
             super.onCleared()
             cachedGoalsByDate.clear()
@@ -386,115 +298,53 @@ class GoalsViewModel
             cacheDate = null
         }
 
-        fun notifyNewGoals(goals: List<IGoal>) {
-            notificationManager.notify(
-                NotificationEvent.Goal(
-                    type = GoalNotificationType.NEW,
-                    goals = goals,
-                ),
-            )
-        }
+        fun notifyNewGoals(goals: List<IGoal>) = notificationManager.notify(NotificationEvent.Goal(GoalNotificationType.NEW, goals))
+        fun notifyYesterdayGoals(goals: List<IGoal>) = notificationManager.notify(NotificationEvent.Goal(GoalNotificationType.YESTERDAY, goals))
 
-        fun notifyYesterdayGoals(goals: List<IGoal>) {
-            notificationManager.notify(
-                NotificationEvent.Goal(
-                    type = GoalNotificationType.YESTERDAY,
-                    goals = goals,
-                ),
-            )
-        }
-
-        /**
-         * Evalúa si hay notificaciones de goals que mostrar y las envía automáticamente.
-         * 1. Verifica si hay goals de ayer en progreso (muestra primero)
-         * 2. Verifica si hay goals de hoy o sugerencias (muestra después)
-         */
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun checkAndNotifyGoals() {
-            val today = dateToString(LocalDate.now())
-
-            // Silently auto-review yesterday's APP_USAGE goals before showing user-facing modals
             autoReviewAppUsageGoals()
-
-            val inProgressResult = getGoalsInProgress()
-            val yesterdayGoals = inProgressResult.getOrNull()
-
-            if (!yesterdayGoals.isNullOrEmpty()) {
-                notifyYesterdayGoals(yesterdayGoals)
-                return // Salir para mostrar solo la de ayer primero
-            }
-
-            val todayResult = getGoalsByDate(today)
-            val todayGoals = todayResult.getOrNull()
-
-            if (!todayGoals.isNullOrEmpty()) {
+            val inProgress = getGoalsInProgress().getOrNull()
+            if (!inProgress.isNullOrEmpty()) {
+                notifyYesterdayGoals(inProgress)
                 return
             }
-
-            val goalDefinitionsResult = getGoalDefinitions()
-            val goalDefinitions = goalDefinitionsResult.getOrNull()
-
-            if (!goalDefinitions.isNullOrEmpty()) {
-                createGoalsFromDefinitions(goalDefinitions)
-                notifyNewGoals(goalDefinitions)
+            if (getGoalsByDate(dateToString(LocalDate.now())).getOrNull().isNullOrEmpty()) {
+                getGoalDefinitions().getOrNull()?.let {
+                    createGoalsFromDefinitions(it)
+                    notifyNewGoals(it)
+                }
             }
         }
 
-        @Suppress("ReturnCount")
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun getDailyGoalsProgress(date: String): Float {
-            val currentGoals = getGoalsByDate(date).getOrElse { return 0f }
-
-            if (currentGoals.isEmpty()) return 0f
-
-            val progress =
-                currentGoals
-                    .map { goal ->
-                        if (goal.target <= 0) {
-                            0f
-                        } else {
-                            (goal.value.toFloat() / goal.target.toFloat()).coerceIn(0f, 1f)
-                        }
-                    }.average()
-                    .toFloat()
-
-            return progress
+            val goals = getGoalsByDate(date).getOrElse { return 0f }
+            if (goals.isEmpty()) return 0f
+            return goals.map { if (it.target <= 0) 0f else (it.value.toFloat() / it.target).coerceIn(0f, 1f) }.average().toFloat()
         }
 
-        /**
-         * Returns the average daily usage (last 7 days) for each app in [goodApps] and [badApps].
-         * Requires PACKAGE_USAGE_STATS permission to have been granted by the user.
-         */
         @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-        override suspend fun getAppsAverageUsage(
-            goodApps: List<String>,
-            badApps: List<String>,
-        ): Result<AppUsageResult> =
-            runCatching {
-                AppUsageResult(
-                    goodAppsUsage = appUsageProvider.getAverageWeeklyUsage(goodApps),
-                    badAppsUsage = appUsageProvider.getAverageWeeklyUsage(badApps),
-                )
-            }
+        override suspend fun getAppsAverageUsage(goodApps: List<String>, badApps: List<String>): Result<AppUsageResult> =
+            runCatching { AppUsageResult(appUsageProvider.getAverageWeeklyUsage(goodApps), appUsageProvider.getAverageWeeklyUsage(badApps)) }
 
         @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-        override suspend fun saveBaselineAppUsage(
-            goodApps: List<String>,
-            badApps: List<String>,
-        ): Result<UserAppUsageDTO> =
+        override suspend fun saveBaselineAppUsage(goodApps: List<String>, badApps: List<String>): Result<UserAppUsageDTO> =
             runCatching {
-                val goodAvgMs = appUsageProvider.getAverageWeeklyUsage(goodApps).sumOf { it.averageDailyUsageMs }
-                val badAvgMs = appUsageProvider.getAverageWeeklyUsage(badApps).sumOf { it.averageDailyUsageMs }
                 val dto = UserAppUsageDTO(
-                    avgGoodDailyUsageMs = goodAvgMs,
-                    avgBadDailyUsageMs = badAvgMs,
+                    appUsageProvider.getAverageWeeklyUsage(goodApps).sumOf { it.averageDailyUsageMs },
+                    appUsageProvider.getAverageWeeklyUsage(badApps).sumOf { it.averageDailyUsageMs }
                 )
                 repository.saveAppUsageBaseline(dto).getOrThrow()
             }
 
-        override suspend fun autoReviewAppUsageGoals(): Result<Unit> =
-            runCatching {
-                repository.autoReviewAppUsageGoals().getOrThrow()
-                Unit
-            }
+        override suspend fun autoReviewAppUsageGoals(): Result<Unit> = runCatching { repository.autoReviewAppUsageGoals().getOrThrow(); Unit }
+
+        @RequiresApi(Build.VERSION_CODES.O)
+        override suspend fun createGoalsFromDefinitions(goalDefinitions: List<GoalDomain>): Result<Unit> {
+            if (goalDefinitions.isEmpty()) return Result.failure(IllegalArgumentException("Empty list"))
+            val today = dateToString(LocalDate.now())
+            cacheMutex.withLock { cachedGoalDefinitions = null; cachedGoalsByDate.remove(today) }
+            return createGoals(goalDefinitions.map { GoalDataMapper.toUserGoalStatusState(it, today) })
+        }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/model/GoalsViewModel.kt
@@ -1,8 +1,8 @@
 package com.bellako.kiwi.features.goals.model
 
 import android.os.Build
-import androidx.annotation.RequiresApi
 import android.util.Log
+import androidx.annotation.RequiresApi
 import com.bellako.kiwi.common.data.UIState
 import com.bellako.kiwi.common.model.BaseViewModel
 import com.bellako.kiwi.common.services.eventbus.EventBus
@@ -76,7 +76,10 @@ class GoalsViewModel
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
-        private suspend fun addGoalsToCache(newGoals: List<UserGoalStatusDomain>, date: String) {
+        private suspend fun addGoalsToCache(
+            newGoals: List<UserGoalStatusDomain>,
+            date: String,
+        ) {
             cacheMutex.withLock {
                 val existing = cachedGoalsByDate[date]
                 cachedGoalsByDate[date] = if (existing == null) newGoals else existing + newGoals
@@ -98,7 +101,7 @@ class GoalsViewModel
                         currentState.copy(
                             goals = resultDTOs.map { UserGoalStatusDataMapper.toState(it) },
                             isLoading = false,
-                            error = null
+                            error = null,
                         )
                     }
                     addGoalsToCache(newGoalsDomain, dateToString(LocalDate.now()))
@@ -110,7 +113,7 @@ class GoalsViewModel
                     _state.update { it.copy(isLoading = false, error = throwable.message) }
                     setUiState(mapExceptionToUIState(throwable))
                     Result.failure(throwable)
-                }
+                },
             )
         }
 
@@ -133,7 +136,7 @@ class GoalsViewModel
                 onFailure = { throwable ->
                     _state.update { it.copy(isLoading = false, error = throwable.message) }
                     Result.failure(throwable)
-                }
+                },
             )
         }
 
@@ -156,11 +159,12 @@ class GoalsViewModel
                 onFailure = { throwable ->
                     _state.update { it.copy(isLoading = false, error = throwable.message) }
                     Result.failure(throwable)
-                }
+                },
             )
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
+        @Suppress("TooGenericExceptionCaught")
         override suspend fun completeGoal(goalId: Long): Result<Unit> {
             _state.update { it.copy(isLoading = true, error = null) }
             val result = repository.completeGoal(goalId)
@@ -169,7 +173,7 @@ class GoalsViewModel
                 onSuccess = { responseDTO ->
                     val updatedDomain = UserGoalStatusDataMapper.toDomain(responseDTO)
                     val updatedState = UserGoalStatusDataMapper.toState(updatedDomain)
-                    
+
                     _state.update { currentState ->
                         val updatedList = currentState.goals.map { if (it.id == updatedState.id) updatedState else it }
                         currentState.copy(goals = updatedList, isLoading = false)
@@ -192,7 +196,7 @@ class GoalsViewModel
                 onFailure = { throwable ->
                     _state.update { it.copy(isLoading = false, error = throwable.message) }
                     Result.failure(throwable)
-                }
+                },
             )
         }
 
@@ -215,7 +219,7 @@ class GoalsViewModel
                 onFailure = { throwable ->
                     _state.update { it.copy(isLoading = false, error = throwable.message) }
                     Result.failure(throwable)
-                }
+                },
             )
         }
 
@@ -249,7 +253,7 @@ class GoalsViewModel
                 onFailure = { throwable ->
                     _state.update { it.copy(isLoading = false, error = throwable.message) }
                     Result.failure(throwable)
-                }
+                },
             )
         }
 
@@ -299,7 +303,9 @@ class GoalsViewModel
         }
 
         fun notifyNewGoals(goals: List<IGoal>) = notificationManager.notify(NotificationEvent.Goal(GoalNotificationType.NEW, goals))
-        fun notifyYesterdayGoals(goals: List<IGoal>) = notificationManager.notify(NotificationEvent.Goal(GoalNotificationType.YESTERDAY, goals))
+
+        fun notifyYesterdayGoals(goals: List<IGoal>) =
+            notificationManager.notify(NotificationEvent.Goal(GoalNotificationType.YESTERDAY, goals))
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun checkAndNotifyGoals() {
@@ -318,6 +324,7 @@ class GoalsViewModel
         }
 
         @RequiresApi(Build.VERSION_CODES.O)
+        @Suppress("ReturnCount")
         override suspend fun getDailyGoalsProgress(date: String): Float {
             val goals = getGoalsByDate(date).getOrElse { return 0f }
             if (goals.isEmpty()) return 0f
@@ -325,26 +332,45 @@ class GoalsViewModel
         }
 
         @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-        override suspend fun getAppsAverageUsage(goodApps: List<String>, badApps: List<String>): Result<AppUsageResult> =
-            runCatching { AppUsageResult(appUsageProvider.getAverageWeeklyUsage(goodApps), appUsageProvider.getAverageWeeklyUsage(badApps)) }
+        override suspend fun getAppsAverageUsage(
+            goodApps: List<String>,
+            badApps: List<String>,
+        ): Result<AppUsageResult> =
+            runCatching {
+                AppUsageResult(
+                    appUsageProvider.getAverageWeeklyUsage(goodApps),
+                    appUsageProvider.getAverageWeeklyUsage(badApps),
+                )
+            }
 
         @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
-        override suspend fun saveBaselineAppUsage(goodApps: List<String>, badApps: List<String>): Result<UserAppUsageDTO> =
+        override suspend fun saveBaselineAppUsage(
+            goodApps: List<String>,
+            badApps: List<String>,
+        ): Result<UserAppUsageDTO> =
             runCatching {
-                val dto = UserAppUsageDTO(
-                    appUsageProvider.getAverageWeeklyUsage(goodApps).sumOf { it.averageDailyUsageMs },
-                    appUsageProvider.getAverageWeeklyUsage(badApps).sumOf { it.averageDailyUsageMs }
-                )
+                val dto =
+                    UserAppUsageDTO(
+                        appUsageProvider.getAverageWeeklyUsage(goodApps).sumOf { it.averageDailyUsageMs },
+                        appUsageProvider.getAverageWeeklyUsage(badApps).sumOf { it.averageDailyUsageMs },
+                    )
                 repository.saveAppUsageBaseline(dto).getOrThrow()
             }
 
-        override suspend fun autoReviewAppUsageGoals(): Result<Unit> = runCatching { repository.autoReviewAppUsageGoals().getOrThrow(); Unit }
+        override suspend fun autoReviewAppUsageGoals(): Result<Unit> =
+            runCatching {
+                repository.autoReviewAppUsageGoals().getOrThrow()
+                Unit
+            }
 
         @RequiresApi(Build.VERSION_CODES.O)
         override suspend fun createGoalsFromDefinitions(goalDefinitions: List<GoalDomain>): Result<Unit> {
             if (goalDefinitions.isEmpty()) return Result.failure(IllegalArgumentException("Empty list"))
             val today = dateToString(LocalDate.now())
-            cacheMutex.withLock { cachedGoalDefinitions = null; cachedGoalsByDate.remove(today) }
+            cacheMutex.withLock {
+                cachedGoalDefinitions = null
+                cachedGoalsByDate.remove(today)
+            }
             return createGoals(goalDefinitions.map { GoalDataMapper.toUserGoalStatusState(it, today) })
         }
     }

--- a/mobile/app/src/main/java/com/bellako/kiwi/features/goals/screens/GoalsModal.kt
+++ b/mobile/app/src/main/java/com/bellako/kiwi/features/goals/screens/GoalsModal.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,7 +26,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.bellako.kiwi.R
 import com.bellako.kiwi.common.screens.components.KiwiTextArguments
 import com.bellako.kiwi.common.screens.components.Kiwi_FixedSizeButton
 import com.bellako.kiwi.common.screens.components.Kiwi_H1
@@ -35,7 +36,6 @@ import com.bellako.kiwi.common.services.eventbus.EventBus
 import com.bellako.kiwi.common.services.eventbus.EventPayload
 import com.bellako.kiwi.common.services.eventbus.EventType
 import com.bellako.kiwi.features.goals.data.GoalCategory
-import com.bellako.kiwi.features.goals.data.GoalDomain
 import com.bellako.kiwi.features.goals.data.GoalStatus
 import com.bellako.kiwi.features.goals.data.GoalType
 import com.bellako.kiwi.features.goals.data.IGoal
@@ -47,6 +47,8 @@ import com.bellako.kiwi.ui.LocalKiwiColors
 import com.bellako.kiwi.ui.Spacing
 import com.bellako.kiwi.ui.getResponsiveSizeHeight
 import com.bellako.kiwi.ui.getResponsiveSizeWidth
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 
 @Composable
@@ -58,6 +60,7 @@ fun GoalsModal(
     onDismiss: () -> Unit = {},
 ) {
     var showWorkInProgressPopup by remember { mutableStateOf(false) }
+    var isProcessing by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
 
     val header =
@@ -97,7 +100,7 @@ fun GoalsModal(
                         .padding(horizontal = getResponsiveSizeHeight(24.dp)),
             ) {
                 Image(
-                    painter = painterResource(id = R.drawable.goals_modal),
+                    painter = painterResource(id = com.bellako.kiwi.R.drawable.goals_modal),
                     contentDescription = null,
                     modifier = Modifier.fillMaxWidth(),
                 )
@@ -147,6 +150,7 @@ fun GoalsModal(
                         .spacedBy(12.dp),
             ) {
                 Kiwi_FixedSizeButton(
+                    enabled = !isProcessing,
                     textArguments =
                         KiwiTextArguments(
                             "Modify",
@@ -158,42 +162,59 @@ fun GoalsModal(
                             .weight(buttonPercentage),
                     onClick = { showWorkInProgressPopup = true },
                 )
-                Kiwi_FixedSizeButton(
-                    textArguments =
-                        KiwiTextArguments(
-                            if (goalModalType == GoalNotificationType.NEW) "Let's go!" else "Done",
-                            color = kiwiColor.colorF,
-                        ),
-                    color = kiwiColor.color8,
-                    modifier =
-                        Modifier
-                            .weight(buttonPercentage),
-                    onClick = {
-                        coroutineScope.launch {
-                            var anyCompleted = false
-                            if (goalModalType == GoalNotificationType.YESTERDAY) {
-                                for (goal in goals) {
-                                    if (goal is UserGoalStatusDomain) {
-                                        if (goal.value == goal.target) {
-                                            goalsViewModel.completeGoal(goalId = goal.id)
-                                            anyCompleted = true
-                                        } else {
-                                            goalsViewModel.uncompleteGoal(goalId = goal.id)
+                Box(
+                    modifier = Modifier.weight(buttonPercentage),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Kiwi_FixedSizeButton(
+                        enabled = !isProcessing,
+                        textArguments =
+                            KiwiTextArguments(
+                                if (isProcessing) "" else if (goalModalType == GoalNotificationType.NEW) "Let's go!" else "Done",
+                                color = kiwiColor.colorF,
+                            ),
+                        color = kiwiColor.color8,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = {
+                            if (isProcessing) return@Kiwi_FixedSizeButton
+                            coroutineScope.launch {
+                                isProcessing = true
+                                var anyCompleted = false
+                                if (goalModalType == GoalNotificationType.YESTERDAY) {
+                                    // Procesar todas las llamadas en paralelo para mejorar rendimiento
+                                    val tasks = goals.filterIsInstance<UserGoalStatusDomain>().map { goal ->
+                                        async {
+                                            if (goal.value >= goal.target) {
+                                                anyCompleted = true
+                                                goalsViewModel.completeGoal(goalId = goal.id)
+                                            } else {
+                                                goalsViewModel.uncompleteGoal(goalId = goal.id)
+                                            }
                                         }
                                     }
+                                    tasks.awaitAll()
+
+                                    goalsViewModel.invalidateGoalsInProgressCache()
+                                    if (anyCompleted) {
+                                        EventBus.emitEvent(
+                                            EventType.MAP_CONTENT_AVAILABLE,
+                                            EventPayload.EmptyPayload(),
+                                        )
+                                    }
                                 }
-                                goalsViewModel.invalidateGoalsInProgressCache()
-                                if (anyCompleted) {
-                                    EventBus.emitEvent(
-                                        EventType.MAP_CONTENT_AVAILABLE,
-                                        EventPayload.EmptyPayload(),
-                                    )
-                                }
+                                isProcessing = false
+                                onDismiss()
                             }
-                            onDismiss()
-                        }
-                    },
-                )
+                        },
+                    )
+                    if (isProcessing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(20.dp),
+                            color = kiwiColor.colorF,
+                            strokeWidth = 2.dp
+                        )
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes the "yesterday's goals" flow in the mobile app: goal completion/uncompletion on the Yesterday Goals modal is now parallelized with a loading indicator instead of blocking sequentially, `GoalsViewModel` is refactored to use `StateFlow.update {}` consistently and `Result.fold` instead of the old `handleResult`/`handleResultSuspend` helpers, and a stray background gradient on the conversation dialogue box is moved so it renders behind the tappable area instead of only behind the text.

## Changes

### Game Logic / Other

- **GoalsModal.kt**: Added an `isProcessing` state that disables the action buttons and shows a `CircularProgressIndicator` while yesterday's goals are being submitted. Goal completion/uncompletion calls are now dispatched concurrently via `async`/`awaitAll` instead of a sequential `for` loop. Changed the completion check from `goal.value == goal.target` to `goal.value >= goal.target` so over-completed goals still count as done.
- **GoalsViewModel.kt**: Replaced direct `_state.value = _state.value.copy(...)` mutations with `_state.update { ... }`, and replaced `handleResult`/`handleResultSuspend` usages with explicit `Result.fold(onSuccess, onFailure)` across `createGoals`, `updateGoalProgress`, `updateGoal`, `completeGoal`, `uncompleteGoal`, and `loadAllGoals`. Removed redundant `setIsLoading`/`setUiState(Loading/Idle)` bracketing in several read paths (`getGoalsByDate`, `getGoalsInProgress`, `getGoalDefinitions`). Wrapped the `EventType.valueOf(...)` lookup in `completeGoal` in a try/catch with logging so an unrecognized `onCompletedEvent` string no longer crashes goal completion. Simplified `checkAndNotifyGoals` control flow and moved `createGoalsFromDefinitions` down in the file. Removed stale KDoc comments.
- **ConversationScreen.kt**: Moved the `LocalKiwiColors` lookup up to the top of `ConversationScreen` and moved the dialogue's vertical gradient background from `DialogueBox` onto the outer tappable `Modifier` chain, so the gradient covers the full advance/skip tap target rather than just the text box. Commented out the flat background color on `ConversationOptionsPanel`. Updated the preview to use `character_liria_base` instead of the no-longer-valid `liria_neutral` character key.

## Schema / Migration Notes

No schema changes.

## Testing

- Ran `./gradlew detekt` / lint on the mobile module to confirm formatting/style passes (per the "Fix detekt" commit).
- Manually verified in the app: open the Yesterday Goals modal, tap "Done" with multiple in-progress goals — confirm the button disables, a spinner shows, all goals resolve concurrently, and the modal dismisses correctly.
- Manually verified the conversation screen: confirm the dialogue background gradient now extends across the full tap area and the options panel no longer shows the old flat background.

## Related

None.
